### PR TITLE
docs(skills): rename browser relay to agent-browser-relay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository provides a local browser-relay so Grais can attach to a **chosen
 
 - The extension manages tab attachment from the toolbar popup.
 - The relay server tunnels requests from the skill into Chrome DevTools Protocol (CDP).
-- The `browser-relay` skill reads and consumes the result payload from the relay and prints JSON directly to stdout.
+- The `agent-browser-relay` skill reads and consumes the result payload from the relay and prints JSON directly to stdout.
 
 ## Capabilities
 - Attach or detach the chosen tab from the toolbar popup.
@@ -33,10 +33,10 @@ export GRAIS_RELAY_PORT=18793
 
 1. Install and open extension
    - After checking out the repository, run `npm run codex:install` to map this copy into:
-     `~/.codex/skills/private/browser-relay`
+     `~/.agents/skills/private/agent-browser-relay`
    - Chrome → `chrome://extensions`
    - Enable Developer mode
-   - Load unpacked and select `~/.codex/skills/private/browser-relay/extension`
+   - Load unpacked and select `~/.agents/skills/private/agent-browser-relay/extension`
    - Pin Grais Debugger icon to the toolbar
    - Run `npm install` once if this checkout has never installed dependencies.
 2. Start relay server in global mode (preferred, always-on):
@@ -70,10 +70,10 @@ export GRAIS_RELAY_PORT=18793
   node scripts/relay-manager.js start --auto-stop-ms 0
   ```
 
-If the `.codex` working tree ever loses subfolders after fetch/reset operations (for example `extension/`), run:
+If the `.agents` working tree ever loses subfolders after fetch/reset operations (for example `extension/`), run:
 
 ```bash
-cd ~/.codex/skills/private/browser-relay
+cd ~/.agents/skills/private/agent-browser-relay
 git sparse-checkout disable
 git config --unset-all core.sparseCheckout || true
 git config --unset-all core.sparseCheckoutCone || true

--- a/README.md
+++ b/README.md
@@ -1,15 +1,70 @@
 # Grais Debugger Chrome Extension (Browser Relay)
 
-Use this project to let Grais read data from the **attached Chrome tab** through a local relay.
+Local browser-relay for Grais: attach a chosen Chrome tab, run CDP reads, and return structured JSON.
 
-## What runs where
-- Extension (`extension/background.js`): attaches/detaches a chosen tab.
-- Relay (`relay-server.js`): local bridge default host/port `127.0.0.1:18793`, configurable per run.
-- Global relay service (`scripts/relay-service.js`): user-level launchd/systemd service for always-on relay lifecycle.
-- Reader (`scripts/read-active-tab.js`): executes reads and prints JSON.
-- Relay sessions: controllers can lease a specific tab id so concurrent agents on one relay stay isolated.
+## Quick Start (Human Setup)
 
-Set once per shell session if you run on a different endpoint:
+### 1) Clone into the global `~/.agents` skills folder
+Recommended (SSH):
+
+```bash
+mkdir -p ~/.agents/skills/private
+git clone git@github.com:Mindgames/Agent-browser-relay.git ~/.agents/skills/private/agent-browser-relay
+cd ~/.agents/skills/private/agent-browser-relay
+npm install
+```
+
+If you prefer HTTPS:
+
+```bash
+mkdir -p ~/.agents/skills/private
+git clone https://github.com/Mindgames/Agent-browser-relay.git ~/.agents/skills/private/agent-browser-relay
+cd ~/.agents/skills/private/agent-browser-relay
+npm install
+```
+
+### 2) Reuse the same skill for Claude CLI (single source of truth)
+If you want one shared installation for both Codex CLI and Claude CLI, symlink Claude's global skill path:
+
+```bash
+mkdir -p ~/.claude/skills
+ln -sfn ~/.agents/skills/private/agent-browser-relay ~/.claude/skills/agent-browser-relay
+```
+
+### 3) Load the extension in Chrome (Developer mode)
+1. Open `chrome://extensions`
+2. Enable **Developer mode**
+3. Click **Load unpacked**
+4. Select this folder:
+   `~/.agents/skills/private/agent-browser-relay/extension`
+5. Pin the **Grais Debugger** toolbar icon
+
+If you move the repo, update this folder path in Chrome and re-load unpacked.
+
+## Skill Directory Structure (`.agents` + `.claude`)
+
+This repo integrates with two different skill roots:
+
+- `~/.agents/skills/agent-browser/`
+  - Houses the `agent-browser` skill/CLI workflow used for browser automation.
+- `~/.agents/skills/private/agent-browser-relay`
+  - Canonical global skill path for this relay project.
+- `~/.claude/skills/agent-browser-relay`
+  - Optional symlink to reuse the same repo in Claude CLI.
+- `~/.agents/skills/private/agent-browser-relay/extension`
+  - Exact Chrome extension directory to load in Developer mode.
+
+Why this matters: one clone under `~/.agents` avoids drift, and Claude can consume the same files via symlink.
+
+## Components
+
+- `extension/background.js`: attach/detach and tab bridge lifecycle.
+- `relay-server.js`: local relay + CDP tunnel.
+- `scripts/relay-service.js`: global `launchd/systemd --user` service lifecycle.
+- `scripts/read-active-tab.js`: read/check CLI that prints JSON.
+- Relay tab leasing (`--tab-id`): isolates concurrent agents to specific tabs.
+
+## Relay Endpoint Defaults
 
 ```bash
 export GRAIS_RELAY_HOST=127.0.0.1
@@ -17,274 +72,148 @@ export GRAIS_RELAY_PORT=18793
 export GRAIS_ATTACH_TIMEOUT_MS=120000
 ```
 
-## 1) Clone and wire skill path
-From your preferred checkout location:
+Set these before commands if your relay endpoint differs.
+
+## Start Relay (Preferred: Global Service)
 
 ```bash
-git clone git@github.com:Replypilot/grais-debug-relay.git
-cd grais-debug-relay
-npm run codex:install
-```
-
-If you use HTTPS:
-
-```bash
-git clone https://github.com/Replypilot/grais-debug-relay.git
-cd grais-debug-relay
-npm run codex:install
-```
-
-If pulls/fetches into this folder ever make `extension/` disappear, the repo has entered sparse mode.
-
-```bash
-cd ~/.codex/skills/private/browser-relay
-git sparse-checkout disable
-git config --unset-all core.sparseCheckout || true
-git config --unset-all core.sparseCheckoutCone || true
-git checkout -- .
-```
-
-This should instantly restore `extension`, `scripts`, and all other tracked folders in the local `.codex` copy.
-
-## 2) One-time Chrome setup
-1. Load extension in Chrome:
-   - Open `chrome://extensions`
-   - Enable Developer mode
-   - Run `npm run codex:install` once after checkout (or after moving the repo)
-   - Load unpacked from `~/.codex/skills/private/browser-relay/extension`
-   - Pin Grais Debugger icon
-
-### Per-tab relay port behavior
-You can run one relay process with multiple ports (`--ports`) and attach different tabs to different ports from the same extension install:
-- If a tab has not been attached before, it uses the global default port (`GRAIS_RELAY_PORT`, default `18793`).
-- After a successful attach, the extension stores that tab’s relay port and reuses it on future attaches.
-- This lets one extension instance survive with mixed ports per tab.
-- Tab-to-port mappings are cleared automatically when a tab is closed.
-
-## 3) Start a session (always this order)
-### Recommended: install as a global service (for multiple agents)
-For shared work across agents, keep one relay service running and never stop it manually until explicitly needed.
-This "global" mode is user-level on your machine (`launchd` on macOS / `systemd --user` on Linux), not a root system daemon.
-
-```bash
-cd grais-debug-relay
-npm run relay:global:install -- --ports 18793 --timeout 12000
-```
-
-Useful lifecycle commands:
-
-```bash
+npm run relay:global:install -- --ports "${GRAIS_RELAY_PORT:-18793}" --timeout 12000
 npm run relay:global:status
-npm run relay:global:stop
+```
+
+Other lifecycle commands:
+
+```bash
 npm run relay:global:start
+npm run relay:global:stop
 npm run relay:global:restart
 npm run relay:global:update
 npm run relay:global:uninstall
 ```
 
-When relay code changes, update by restarting/reinstalling so the new binary is picked up by the managed service (only when explicitly requested/planned):
+### Legacy one-off mode (fallback)
 
 ```bash
-git pull
-npm run relay:global:update -- --wait-for-ready --ready-timeout-ms 10000
-```
-
-If you prefer one-off startup instead of service management, use the existing `relay:start` flow in the steps below.
-### Legacy one-off start
-
-1. Start relay:
-
-```bash
-cd grais-debug-relay
-npm run relay:start -- --status-timeout-ms 3000
-```
-
-Use explicit host/port if you are not on defaults:
-
-```bash
-cd grais-debug-relay
-npm run relay:start -- --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --status-timeout-ms 3000
-```
-
-To start multiple listeners in one relay process:
-
-```bash
-npm run relay:start -- --ports 18793,18794 --status-timeout-ms 3000
-```
-
-2. Confirm relay is up:
-
-```bash
+npm run relay:start
 npm run relay:status -- --status-timeout-ms 3000
 ```
 
-To inspect all active ports/tabs:
+Or explicit host/port:
 
 ```bash
-npm run relay:status -- --all --status-timeout-ms 3000
+npm run relay:start -- --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --status-timeout-ms 3000
 ```
 
-Expected for multi-port:
-- `ports`: when multiple listeners are configured, includes each configured port with `extensionConnected`, `activeTab`, and `attachedTabs`.
-- `ok: true`
-- `extensionConnected: true` after you complete the attach step below
+## Required Attach Gate (Before Any Read)
 
-Sample fields:
-- `attachedTabs`: array of attached browser tabs (`tabId`, `title`, `url`, `targetId`)
-- `extensionConnected`: relay-side extension websocket state per port
+After relay startup, a human must attach the target tab:
+1. Open/focus target tab in Chrome.
+2. Open Grais Debugger popup.
+3. Click **Attach this tab**.
+4. Confirm badge shows `ON`.
 
-3. Human attach step (required for agent runs):
-   - Open/focus target tab in Chrome
-   - Click Grais Debugger icon to open the popup
-   - Optional: set a **Tab port** override for that tab if you use multiple relays
-   - Click **Attach this tab**
-   - Confirm badge shows `ON`
-   - Tell agent when done
-
-4. Verify attach before any read:
+Then run:
 
 ```bash
 node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
 ```
 
-For multi-agent runs (recommended), verify the assigned tab lease explicitly:
+For multi-agent runs, always target a specific tab lease:
 
 ```bash
 node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
 ```
 
-Continue only when this command succeeds.
+## Health Check (Timeout Required)
 
-Note:
-- Reads target the currently attached tab unless you pass `--tab-id`.
-- With `--tab-id`, the reader opens a relay session and claims a tab lease so commands/events stay scoped to that tab.
-- If attach state drifts (for example after reconnect/reload), open the icon popup on the intended tab and click **Attach this tab**, then run the check command again.
-- Relay restart policy for agents: do not restart the running relay for routine tasks or just because local files changed; restart only on explicit human instruction or unrecoverable hard failure.
+Never run bare `curl` for relay checks. Use timeout:
 
-## 4) Read data
-Default structured payload (`url`, `title`, `text`, `links`, `metaDescription`):
+```bash
+curl --max-time 3 -sS "http://${GRAIS_RELAY_HOST:-127.0.0.1}:${GRAIS_RELAY_PORT:-18793}/status"
+```
+
+Continue only when status reports:
+- `extensionConnected: true`
+- low queue depth
+
+## Read Data
+
+Default extraction (`url`, `title`, `text`, `links`, `metaDescription`):
 
 ```bash
 node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --pretty false
 ```
 
-Target a specific tab id (recommended for concurrent agents):
+Specific tab lease:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id 123 --pretty false
+node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --pretty false
 ```
 
 Full DOM:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --expression "document.documentElement.outerHTML" --pretty false
+node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --expression "document.documentElement.outerHTML" --pretty false
 ```
 
-Screenshot (full page):
+Screenshot:
 
 ```bash
-node scripts/read-active-tab.js \
-  --host "${GRAIS_RELAY_HOST:-127.0.0.1}" \
-  --port "${GRAIS_RELAY_PORT:-18793}" \
-  --screenshot \
-  --screenshot-full-page \
-  --screenshot-path "./tmp/page.png" \
-  --pretty false
+node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --screenshot --screenshot-full-page --screenshot-path "./tmp/page.png" --pretty false
 ```
 
 WhatsApp messages:
 
 ```bash
-node scripts/read-active-tab.js \
-  --host "${GRAIS_RELAY_HOST:-127.0.0.1}" \
-  --port "${GRAIS_RELAY_PORT:-18793}" \
-  --preset whatsapp-messages \
-  --selector "#main [data-testid=\"conversation-panel-messages\"], #main" \
-  --max-messages 200 \
-  --pretty false
+node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --preset whatsapp-messages --selector "#main [data-testid=\"conversation-panel-messages\"], #main" --max-messages 200 --pretty false
 ```
 
-## 5) Relay lifecycle
-Global service mode:
+## Multi-Port Behavior
 
-```bash
-npm run relay:global:status
-npm run relay:global:stop
-npm run relay:global:start
-npm run relay:global:restart
-```
+- Tabs without a saved mapping use `GRAIS_RELAY_PORT` (default `18793`).
+- After successful attach, tab-to-port mapping is stored and reused.
+- Closing a tab clears its mapping.
 
-Legacy one-off mode:
-
-Status:
-
-```bash
-npm run relay:status -- --status-timeout-ms 3000
-```
-
-Stop:
-
-```bash
-npm run relay:stop
-```
-
-Notes:
-- `relay:global:install` sets `--max-runtime-ms 0` (no auto-stop) for always-on relay behavior.
-- `relay:start` auto-stops after 2 hours by default.
-- Override: `node scripts/relay-manager.js start --auto-stop-ms 10800000`
-- Disable auto-stop: `node scripts/relay-manager.js start --auto-stop-ms 0`
-- Multi-port status check:
+Inspect all ports/tabs:
 
 ```bash
 npm run relay:status -- --all --status-timeout-ms 3000
 ```
 
-## 6) Troubleshooting
+## Troubleshooting
+
 - Relay unreachable:
 
 ```bash
 npm run relay:status -- --status-timeout-ms 3000
 ```
 
-- Extension bridge disconnected (`extensionConnected: false`):
-  - Re-focus target tab
-  - Click extension icon again
-  - Re-run `npm run relay:status -- --status-timeout-ms 3000`
-  - Re-run check command
+- Attachment lost after navigation/reload:
+  - Re-open popup on that tab.
+  - Click **Attach this tab** again.
+  - Re-run the `--check --wait-for-attach` command.
 
-- See all active port status and attached tabs:
-
-```bash
-npm run relay:status -- --all --status-timeout-ms 3000
-```
-
-- Add or remove relay listeners without restarting:
+- Sparse checkout accidentally hid folders in canonical skill copy:
 
 ```bash
-node scripts/relay-manager.js ports --action add --ports 18795
-node scripts/relay-manager.js ports --action remove --ports 18794
+cd ~/.agents/skills/private/agent-browser-relay
+git sparse-checkout disable
+git config --unset-all core.sparseCheckout || true
+git config --unset-all core.sparseCheckoutCone || true
+git checkout -- .
 ```
 
-- `Timed out waiting for Runtime.evaluate`:
-  - Tab is usually not attached
-  - Re-attach and re-run:
+## Agent Contract (Canonical Commands)
 
-```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
-```
+Use only these script names:
 
-- Clean restart:
+- `npm run relay:global:install`
+- `npm run relay:global:status`
+- `npm run relay:global:start`
+- `npm run relay:global:stop`
+- `npm run relay:start`
+- `npm run relay:status`
+- `npm run relay:stop`
+- `node scripts/read-active-tab.js`
 
-```bash
-npm run relay:stop
-npm run relay:start -- --status-timeout-ms 3000
-```
-
-or in global service mode:
-
-```bash
-npm run relay:global:restart -- --wait-for-ready --ready-timeout-ms 10000
-```
-
-Note: every successful read/check response contains:
-`source.relayHost`, `source.relayPort`, `source.relayStatusUrl`, and `source.relayWebSocketUrl` so humans can identify which relay endpoint is active.
+Do not restart relay just because local files changed. Restart only when explicitly requested by a human, or for hard recovery failures.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: browser-relay
+name: agent-browser-relay
 description: Read metadata and DOM payloads from an attached Chrome tab through a local Grais relay extension.
 ---
 
-# Browser Relay
+# Agent Browser Relay
 
 Use this skill to attach to a chosen Chrome tab through the bundled Grais Debugger extension and extract tab metadata or DOM data for analysis.
 
@@ -46,7 +46,7 @@ export GRAIS_ATTACH_TIMEOUT_MS=120000
 
    - `chrome://extensions`
    - Enable developer mode
-   - Load unpacked from `~/.codex/skills/private/browser-relay/extension`
+   - Load unpacked from `~/.agents/skills/private/agent-browser-relay/extension`
 
 3. Attach the extension to the target tab (open toolbar popup and click attach)
 
@@ -54,10 +54,10 @@ export GRAIS_ATTACH_TIMEOUT_MS=120000
 
    Agent requirement: after `relay:start`, pause and ask the human to do this attach step, then wait for confirmation before continuing.
 
-   If your `.codex` skill folder drops `extension/` after a `git fetch` or pull, repair it from the repo:
+   If your `.agents` skill folder drops `extension/` after a `git fetch` or pull, repair it from the repo:
 
    ```bash
-   cd ~/.codex/skills/private/browser-relay
+   cd ~/.agents/skills/private/agent-browser-relay
    git sparse-checkout disable
    git config --unset-all core.sparseCheckout || true
    git config --unset-all core.sparseCheckoutCone || true

--- a/scripts/codex-skill-link.sh
+++ b/scripts/codex-skill-link.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-CANONICAL_ROOT="${HOME}/.codex/skills/private"
-CANONICAL_SKILL_PATH="${CANONICAL_ROOT}/browser-relay"
+CANONICAL_ROOT="${HOME}/.agents/skills/private"
+CANONICAL_SKILL_PATH="${CANONICAL_ROOT}/agent-browser-relay"
+LEGACY_ALIAS_PATH="${CANONICAL_ROOT}/browser-relay"
 CANONICAL_EXTENSION_PATH="${CANONICAL_SKILL_PATH}/extension"
 
 MODE="install"
@@ -25,10 +26,13 @@ Usage:
   bash scripts/codex-skill-link.sh --force   # replace existing non-symlink path
 
 The script always links this repository to:
-  ~/.codex/skills/private/browser-relay
+  ~/.agents/skills/private/agent-browser-relay
 
 Then Chrome should load:
-  ~/.codex/skills/private/browser-relay/extension
+  ~/.agents/skills/private/agent-browser-relay/extension
+
+Compatibility alias:
+  ~/.agents/skills/private/browser-relay -> ~/.agents/skills/private/agent-browser-relay
 EOF
       exit 0
       ;;
@@ -56,6 +60,7 @@ resolve_link_target() {
 }
 
 mkdir -p "$CANONICAL_ROOT"
+NEED_CANONICAL_LINK=1
 
 if [[ "$MODE" == "check" ]]; then
   if [[ -L "$CANONICAL_SKILL_PATH" ]]; then
@@ -98,20 +103,34 @@ if [[ -d "$CANONICAL_SKILL_PATH" && ! -L "$CANONICAL_SKILL_PATH" ]]; then
     echo "[codex-skill] Reusing existing repository path at $CANONICAL_SKILL_PATH"
     echo "[codex-skill] Chrome load target:"
     echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"
-    exit 0
-  fi
+    NEED_CANONICAL_LINK=0
+  else
+    if [[ "$FORCE" -ne 1 ]]; then
+      echo "[codex-skill] ERROR: $CANONICAL_SKILL_PATH exists and is a directory. Use --force to replace it." >&2
+      exit 2
+    fi
 
-  if [[ "$FORCE" -ne 1 ]]; then
-    echo "[codex-skill] ERROR: $CANONICAL_SKILL_PATH exists and is a directory. Use --force to replace it." >&2
-    exit 2
+    rm -rf "$CANONICAL_SKILL_PATH"
   fi
-
-  rm -rf "$CANONICAL_SKILL_PATH"
 fi
 
-ln -sfn "$REPO_ROOT" "$CANONICAL_SKILL_PATH"
+if [[ "$NEED_CANONICAL_LINK" -eq 1 ]]; then
+  ln -sfn "$REPO_ROOT" "$CANONICAL_SKILL_PATH"
+fi
+
+if [[ -e "$LEGACY_ALIAS_PATH" && ! -L "$LEGACY_ALIAS_PATH" ]]; then
+  if [[ "$FORCE" -ne 1 ]]; then
+    echo "[codex-skill] ERROR: legacy alias path exists and is a directory. Use --force to replace it: $LEGACY_ALIAS_PATH" >&2
+    exit 2
+  fi
+  rm -rf "$LEGACY_ALIAS_PATH"
+fi
+
+ln -sfn "$CANONICAL_SKILL_PATH" "$LEGACY_ALIAS_PATH"
 
 echo "[codex-skill] Linked skill workspace:"
 echo "[codex-skill]   $CANONICAL_SKILL_PATH -> $REPO_ROOT"
+echo "[codex-skill] Linked compatibility alias:"
+echo "[codex-skill]   $LEGACY_ALIAS_PATH -> $CANONICAL_SKILL_PATH"
 echo "[codex-skill] Chrome load target:"
 echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"


### PR DESCRIPTION
## Summary
- Rename the canonical global skill path to `~/.agents/skills/private/agent-browser-relay`.
- Keep backward compatibility by creating `~/.agents/skills/private/browser-relay` as an alias symlink.
- Align docs and skill metadata with the new name and path conventions.

## Why this change
- The old naming and path guidance mixed legacy conventions and created avoidable setup friction.
- Standardizing on `agent-browser-relay` under `~/.agents` makes install/load instructions clearer and consistent with the current global skills layout.
- Backward compatibility avoids breaking existing setups still referencing `browser-relay`.

## What changed
- Installer/linking behavior:
  - Updated `scripts/codex-skill-link.sh` to use `~/.agents/skills/private/agent-browser-relay` as canonical path.
  - Added compatibility alias creation: `~/.agents/skills/private/browser-relay -> ~/.agents/skills/private/agent-browser-relay`.
  - Improved installer flow so alias creation still runs when canonical path already exists and points to this repo.
- Documentation updates:
  - Updated `README.md` setup instructions to clone/load extension from the new canonical path.
  - Updated `AGENTS.md` setup and troubleshooting paths to `.agents` + `agent-browser-relay`.
  - Updated `SKILL.md` metadata name to `agent-browser-relay` and path examples accordingly.

## Files changed
- `AGENTS.md`
- `README.md`
- `SKILL.md`
- `scripts/codex-skill-link.sh`

## QA / Testing
- Command: `pnpm lint` — Result: passed.
- Command: `pnpm knip` — Result: passed (repository reports knip is not configured and skipped).
- Command: `pnpm build` — Result: passed.
- Command: `bash -n scripts/codex-skill-link.sh` — Result: passed.
- Command: `HOME=$(mktemp -d) bash scripts/codex-skill-link.sh && HOME=$(mktemp -d) bash scripts/codex-skill-link.sh --check` — Result: installer/check logic validated in isolated HOME, canonical + alias links created as expected.

## Risks and impacts
- Low risk: changes are documentation + installer path wiring.
- Main risk is local environments relying on old paths; mitigated by creating and preserving the legacy alias symlink.

## Rollback plan
- Revert this PR commit to restore previous path naming and installer behavior.
- If needed locally, remove new links under `~/.agents/skills/private` and re-run previous installer version.

## Related issues
- No confirmed issue number was provided.

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
