### PR TITLE
docs(skills): align relay naming and README flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
-# Grais Debugger Chrome Extension (Browser Relay)
+# Agent Browser Relay (Chrome)
 
-Local browser-relay for Grais: attach a chosen Chrome tab, run CDP reads, and return structured JSON.
+Agent Browser Relay lets your agent control and read from tabs in your real Chrome session, including multiple attached tabs in parallel, without forcing a separate browser profile.
+
+## Why Use It
+
+- Run agent reads on multiple attached tabs concurrently with per-tab lease isolation (`--tab-id`).
+- Execute on background/non-focused tabs while you continue using your browser.
+- Keep your real logged-in session (cookies, auth state, extensions) instead of re-automating login in a disposable browser.
+- Extract structured page data, full DOM, screenshots, and chat/message presets via one CLI.
+- Recover from tab/context changes with reconnect + attach checks designed for long-running agent workflows.
+- Stop safely when CAPTCHA/human verification appears, and alert the user before continuing.
+
+## What You Get
+
+- Chrome extension bridge for attach/detach from the toolbar popup.
+- Local relay service with global always-on mode (`launchd` / `systemd --user`).
+- Scriptable read/check interface (`node scripts/read-active-tab.js`) for agent workflows.
+- Explicit tab leasing model for multi-agent safety on shared relay infrastructure.
 
 ## Quick Start (Human Setup)
 
@@ -217,3 +233,9 @@ Use only these script names:
 - `node scripts/read-active-tab.js`
 
 Do not restart relay just because local files changed. Restart only when explicitly requested by a human, or for hard recovery failures.
+
+If CAPTCHA/human verification appears, stop immediately, alert the user, and wait for explicit confirmation before continuing.
+
+## Recommended Companion
+
+For human-in-the-loop workflows, we recommend using [attention-please](https://github.com/Mindgames/attention-please) so the user gets an immediate alert when manual action is needed (for example CAPTCHA or verification gates).


### PR DESCRIPTION
## Summary
- Rename the canonical skill installation path/name to `agent-browser-relay` under `~/.agents`.
- Keep backward compatibility with a legacy alias symlink for `browser-relay`.
- Reposition README to lead with capabilities first and add explicit CAPTCHA/verification stop-and-alert guidance.

## Why this change
- Setup naming/path guidance needed to match the current global skills layout and avoid ambiguity.
- Existing users should not break when moving from `browser-relay` naming.
- README should immediately communicate value before setup details.
- Human-verification gates (CAPTCHA/verification) need explicit operational guidance for safe agent runs.

## What changed
- Skill/linking path updates:
  - Canonical path now targets `~/.agents/skills/private/agent-browser-relay`.
  - Installer now creates compatibility alias `~/.agents/skills/private/browser-relay -> .../agent-browser-relay`.
  - Installer flow fixed so alias creation still runs when canonical path already exists and points to repo.
- Documentation updates:
  - Updated `README.md`, `SKILL.md`, and `AGENTS.md` path/name references to `agent-browser-relay`.
  - Updated README opening sections to capability-first framing.
  - Added CAPTCHA/verification stop + user alert behavior in README.
  - Added recommendation for companion alert skill: `attention-please`.

## Files changed
- `AGENTS.md`
- `README.md`
- `SKILL.md`
- `scripts/codex-skill-link.sh`

## QA / Testing
- Command: `pnpm lint` — Result: passed.
- Command: `pnpm knip` — Result: passed (`knip` is configured as skipped in this repository).
- Command: `pnpm build` — Result: passed.
- Command: `bash -n scripts/codex-skill-link.sh` — Result: passed.
- Command: `HOME=$(mktemp -d) bash scripts/codex-skill-link.sh && HOME=<same> bash scripts/codex-skill-link.sh --check` — Result: passed; canonical + legacy alias links verified.

## Risks and impacts
- Low-to-moderate risk: documentation + installer path behavior.
- Primary risk: legacy path consumers; mitigated by compatibility alias.

## Rollback plan
- Revert this PR commit set.
- Re-run prior installer logic if legacy-only path behavior is required.

## Related issues
- No confirmed issue number was provided.

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
