### PR TITLE
refactor(relay): rebrand extension and remove env defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# Grais Debugger Chrome Extension (Browser Relay)
+# Agent Browser Relay Chrome Extension (Browser Relay)
 
 ## Purpose
-This repository provides a local browser-relay so Grais can attach to a **chosen Chrome tab**, execute script in that tab, and return structured page data to an agent workflow.
+This repository provides a local browser-relay so an agent can attach to a **chosen Chrome tab**, execute script in that tab, and return structured page data to an agent workflow.
 
 - The extension manages tab attachment from the toolbar popup.
 - The relay server tunnels requests from the skill into Chrome DevTools Protocol (CDP).
@@ -24,12 +24,7 @@ This repository provides a local browser-relay so Grais can attach to a **chosen
 
 ## Setup
 ### Relay endpoint
-Default host/port is `127.0.0.1:18793`. If your relay is on a different port, set these env vars before any command:
-
-```bash
-export GRAIS_RELAY_HOST=127.0.0.1
-export GRAIS_RELAY_PORT=18793
-```
+Default host/port is `127.0.0.1:18793` (set in code). Override per command with `--host` / `--port` if needed.
 
 1. Install and open extension
    - After checking out the repository, run `npm run codex:install` to map this copy into:
@@ -37,12 +32,12 @@ export GRAIS_RELAY_PORT=18793
    - Chrome → `chrome://extensions`
    - Enable Developer mode
    - Load unpacked and select `~/.agents/skills/private/agent-browser-relay/extension`
-   - Pin Grais Debugger icon to the toolbar
+   - Pin Agent Browser Relay icon to the toolbar
    - Run `npm install` once if this checkout has never installed dependencies.
 2. Start relay server in global mode (preferred, always-on):
 
    ```bash
-   npm run relay:global:install -- --ports "${GRAIS_RELAY_PORT:-18793}" --timeout 12000
+   npm run relay:global:install -- --ports "18793" --timeout 12000
    npm run relay:global:status
    ```
 
@@ -57,9 +52,7 @@ export GRAIS_RELAY_PORT=18793
    If your relay is on another host/port:
 
    ```bash
-   export GRAIS_RELAY_HOST=127.0.0.1
-   export GRAIS_RELAY_PORT=18793
-   npm run relay:start -- --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}"
+   npm run relay:start -- --host "127.0.0.1" --port "18793"
    ```
 
 4. `relay:start` keeps relay running and auto-stops after 2 hours by default (to avoid start/stop churn).
@@ -104,14 +97,14 @@ This refreshes sparse state and restores all missing tracked directories in the 
    - Before any read, the agent must run:
 
    ```bash
-   node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms 120000
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms 120000
    ```
 
    Continue only when this check succeeds.
 
 ### Per-tab relay port behavior
 - If you start relay on multiple ports, one extension install can manage different ports by tab.
-- If a tab has no saved relay-port mapping, it uses the global default (`GRAIS_RELAY_PORT`, default `18793`).
+- If a tab has no saved relay-port mapping, it uses the global default relay port (`18793`).
 - On successful attach, the extension stores that tab’s relay port mapping.
 - Returning to that tab reuses the mapped port automatically.
 - Closing a tab clears its tab->port mapping.
@@ -127,7 +120,7 @@ This refreshes sparse state and restores all missing tracked directories in the 
   - `npm run relay:stop`
   - `node scripts/read-active-tab.js`
 - After relay startup (`relay:global:start` / `relay:global:install` or `relay:start`), agent must stop and ask the human to attach the target tab, then wait for confirmation.
-- Agent must run `node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms 120000` before any data read and continue only on success.
+- Agent must run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms 120000` before any data read and continue only on success.
 - For multi-agent or concurrent runs, agent must use tab leasing by setting `--tab-id <tabId>` on all read/check commands.
 - Agent must resolve `tabId` from relay status (`/status` or `npm run relay:status -- --all`) and explicitly target that tab.
 - Agent must not stop/restart relay during a task unless the human explicitly asks for restart or a hard failure requires it.
@@ -138,7 +131,7 @@ This refreshes sparse state and restores all missing tracked directories in the 
 Before running reads, also verify relay health:
 
 ```bash
-curl --max-time 3 -sS "http://${GRAIS_RELAY_HOST:-127.0.0.1}:${GRAIS_RELAY_PORT:-18793}/status"
+curl --max-time 3 -sS "http://127.0.0.1:18793/status"
 ```
 
 Expect `extensionConnected: true` and low queue depth before running fetches.
@@ -146,16 +139,16 @@ Never run bare `curl` without a timeout for relay checks.
 
 ## Workflow
 1. Open and focus the target tab(s) in Chrome.
-2. Open the Grais Debugger popup and click "Attach this tab" for each tab an agent should use.
+2. Open the Agent Browser Relay popup and click "Attach this tab" for each tab an agent should use.
 3. Resolve each target `tabId` from status output (`npm run relay:status -- --all --status-timeout-ms 3000`).
 4. Optional: spawn a new tab via relay CDP forwarding (`Target.createTarget`), then re-run status and resolve the new `tabId`.
 5. Validate readiness before each read:
 
    ```bash
-   node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --check
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check
    ```
    ```bash
-   node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms 120000
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms 120000
    ```
 
    If relay is reachable this command waits for an active attachment instead of immediate failure.
@@ -163,7 +156,7 @@ Never run bare `curl` without a timeout for relay checks.
 6. Read default extraction from a specific leased tab:
 
    ```bash
-   node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --pretty false
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --pretty false
    ```
 
 7. Read full DOM:
@@ -175,8 +168,8 @@ Never run bare `curl` without a timeout for relay checks.
 
    ```bash
    node scripts/read-active-tab.js \
-     --host "${GRAIS_RELAY_HOST:-127.0.0.1}" \
-     --port "${GRAIS_RELAY_PORT:-18793}" \
+     --host "127.0.0.1" \
+     --port "18793" \
      --tab-id "<TAB_ID>" \
      --expression "document.documentElement.outerHTML" --pretty false
    ```
@@ -193,8 +186,8 @@ Never run bare `curl` without a timeout for relay checks.
 
    ```bash
    node scripts/read-active-tab.js \
-     --host "${GRAIS_RELAY_HOST:-127.0.0.1}" \
-     --port "${GRAIS_RELAY_PORT:-18793}" \
+     --host "127.0.0.1" \
+     --port "18793" \
      --tab-id "<TAB_ID>" \
      --screenshot \
      --screenshot-full-page \
@@ -214,8 +207,8 @@ Never run bare `curl` without a timeout for relay checks.
 
    ```bash
    node scripts/read-active-tab.js \
-     --host "${GRAIS_RELAY_HOST:-127.0.0.1}" \
-     --port "${GRAIS_RELAY_PORT:-18793}" \
+     --host "127.0.0.1" \
+     --port "18793" \
      --tab-id "<TAB_ID>" \
      --preset whatsapp-messages \
      --selector "#main [data-testid=\"conversation-panel-messages\"], #main" \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After install, the skill is available at:
 3. Click **Load unpacked**
 4. Select this folder:
    `~/.agents/skills/agent-browser-relay/extension`
-5. Pin the **Grais Debugger** toolbar icon
+5. Pin the **Agent Browser Relay** toolbar icon
 
 ### 3) Contributor install (optional, for editing this repo)
 If you are developing this skill locally, clone to the canonical path:
@@ -77,18 +77,17 @@ Why this matters: installer-based setup gives a stable path and keeps Codex/Clau
 
 ## Relay Endpoint Defaults
 
-```bash
-export GRAIS_RELAY_HOST=127.0.0.1
-export GRAIS_RELAY_PORT=18793
-export GRAIS_ATTACH_TIMEOUT_MS=120000
-```
+Defaults are set directly in code:
+- Host: `127.0.0.1`
+- Port: `18793`
+- Attach timeout: `120000` ms
 
-Set these before commands if your relay endpoint differs.
+Override per command with flags such as `--host`, `--port`, and `--attach-timeout-ms` when needed.
 
 ## Start Relay (Preferred: Global Service)
 
 ```bash
-npm run relay:global:install -- --ports "${GRAIS_RELAY_PORT:-18793}" --timeout 12000
+npm run relay:global:install -- --ports 18793 --timeout 12000
 npm run relay:global:status
 ```
 
@@ -112,27 +111,27 @@ npm run relay:status -- --status-timeout-ms 3000
 Or explicit host/port:
 
 ```bash
-npm run relay:start -- --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --status-timeout-ms 3000
+npm run relay:start -- --host 127.0.0.1 --port 18793 --status-timeout-ms 3000
 ```
 
 ## Required Attach Gate (Before Any Read)
 
 After relay startup, a human must attach the target tab:
 1. Open/focus target tab in Chrome.
-2. Open Grais Debugger popup.
+2. Open Agent Browser Relay popup.
 3. Click **Attach this tab**.
 4. Confirm badge shows `ON`.
 
 Then run:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
+node scripts/read-active-tab.js --check --wait-for-attach --attach-timeout-ms 120000
 ```
 
 For multi-agent runs, always target a specific tab lease:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
+node scripts/read-active-tab.js --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms 120000
 ```
 
 ## Health Check (Timeout Required)
@@ -140,7 +139,7 @@ node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "
 Never run bare `curl` for relay checks. Use timeout:
 
 ```bash
-curl --max-time 3 -sS "http://${GRAIS_RELAY_HOST:-127.0.0.1}:${GRAIS_RELAY_PORT:-18793}/status"
+curl --max-time 3 -sS "http://127.0.0.1:18793/status"
 ```
 
 Continue only when status reports:
@@ -152,36 +151,36 @@ Continue only when status reports:
 Default extraction (`url`, `title`, `text`, `links`, `metaDescription`):
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --pretty false
+node scripts/read-active-tab.js --pretty false
 ```
 
 Specific tab lease:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --pretty false
+node scripts/read-active-tab.js --tab-id "<TAB_ID>" --pretty false
 ```
 
 Full DOM:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --expression "document.documentElement.outerHTML" --pretty false
+node scripts/read-active-tab.js --tab-id "<TAB_ID>" --expression "document.documentElement.outerHTML" --pretty false
 ```
 
 Screenshot:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --screenshot --screenshot-full-page --screenshot-path "./tmp/page.png" --pretty false
+node scripts/read-active-tab.js --tab-id "<TAB_ID>" --screenshot --screenshot-full-page --screenshot-path "./tmp/page.png" --pretty false
 ```
 
 WhatsApp messages:
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --preset whatsapp-messages --selector "#main [data-testid=\"conversation-panel-messages\"], #main" --max-messages 200 --pretty false
+node scripts/read-active-tab.js --tab-id "<TAB_ID>" --preset whatsapp-messages --selector "#main [data-testid=\"conversation-panel-messages\"], #main" --max-messages 200 --pretty false
 ```
 
 ## Multi-Port Behavior
 
-- Tabs without a saved mapping use `GRAIS_RELAY_PORT` (default `18793`).
+- Tabs without a saved mapping use the relay default port (`18793`).
 - After successful attach, tab-to-port mapping is stored and reused.
 - Closing a tab clears its mapping.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,21 +1,19 @@
 ---
 name: agent-browser-relay
-description: Read metadata and DOM payloads from an attached Chrome tab through a local Grais relay extension.
+description: Read metadata and DOM payloads from an attached Chrome tab through a local Agent Browser Relay extension.
 ---
 
 # Agent Browser Relay
 
-Use this skill to attach to a chosen Chrome tab through the bundled Grais Debugger extension and extract tab metadata or DOM data for analysis.
+Use this skill to attach to a chosen Chrome tab through the bundled Agent Browser Relay extension and extract tab metadata or DOM data for analysis.
 
 ## Quick start
 
-Use these defaults for the active relay endpoint:
-
-```bash
-export GRAIS_RELAY_HOST=127.0.0.1
-export GRAIS_RELAY_PORT=18793
-export GRAIS_ATTACH_TIMEOUT_MS=120000
-```
+Defaults are set in code:
+- Host: `127.0.0.1`
+- Port: `18793`
+- Attach timeout: `120000` ms
+Override per command with `--host`, `--port`, and `--attach-timeout-ms` when needed.
 
 1. Wire canonical skill path
 
@@ -32,7 +30,7 @@ export GRAIS_ATTACH_TIMEOUT_MS=120000
    Or pin host/port explicitly:
 
    ```bash
-   npm run relay:start -- --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --status-timeout-ms 3000
+   npm run relay:start -- --host "127.0.0.1" --port "18793" --status-timeout-ms 3000
    ```
 
    `relay:start` auto-stops after 2 hours by default. Override if needed:
@@ -67,20 +65,20 @@ export GRAIS_ATTACH_TIMEOUT_MS=120000
 4. Check readiness and attach state
 
    ```bash
-   node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms "120000"
    ```
 
    For multi-agent runs, include the assigned tab id:
 
    ```bash
-   node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "120000"
    ```
 
    Continue only if this command returns success.
 
 ### Per-tab relay port behavior
 - If you run one relay process with multiple ports, the extension can manage different relay ports per attached tab.
-- A tab with no saved relay-port mapping uses the global default (`GRAIS_RELAY_PORT`, default `18793`).
+- A tab with no saved relay-port mapping uses the global default relay port (`18793`).
 - After a successful attach, the extension saves that tab’s mapped relay port and reuses it automatically.
 - Closed tabs have their mapping removed automatically.
 
@@ -94,10 +92,10 @@ export GRAIS_ATTACH_TIMEOUT_MS=120000
   - `node scripts/read-active-tab.js`
 - For relay health checks, always use explicit timeouts to avoid hangs:
   - `npm run relay:status -- --status-timeout-ms 3000`
-  - `curl --max-time 3 -sS "http://${GRAIS_RELAY_HOST:-127.0.0.1}:${GRAIS_RELAY_PORT:-18793}/status"`
+  - `curl --max-time 3 -sS "http://127.0.0.1:18793/status"`
   - `npm run relay:status -- --all --status-timeout-ms 3000`
 - After `relay:start`, pause and ask the human to attach the target tab before any read.
-- Run `node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --check --wait-for-attach --attach-timeout-ms "${GRAIS_ATTACH_TIMEOUT_MS:-120000}"` before reads and proceed only when it succeeds.
+- Run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms "120000"` before reads and proceed only when it succeeds.
 - For concurrent/multi-agent usage, always pass `--tab-id <tabId>` on check/read commands so each agent gets a tab lease.
 - Do not stop/restart relay during the task unless the human requests it or recovery is explicitly required.
 - Do not restart relay only because code was updated locally; updates are applied on next explicit human-approved restart.
@@ -133,11 +131,11 @@ export GRAIS_ATTACH_TIMEOUT_MS=120000
 ## Common command examples
 
 ```bash
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --pretty false
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --tab-id 123 --pretty false
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --expression "document.documentElement.outerHTML"
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --screenshot --screenshot-full-page --screenshot-path "./tmp/page.png"
-node scripts/read-active-tab.js --host "${GRAIS_RELAY_HOST:-127.0.0.1}" --port "${GRAIS_RELAY_PORT:-18793}" --preset whatsapp-messages --max-messages 200 --selector "#main"
+node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --pretty false
+node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id 123 --pretty false
+node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --expression "document.documentElement.outerHTML"
+node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --screenshot --screenshot-full-page --screenshot-path "./tmp/page.png"
+node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --preset whatsapp-messages --max-messages 200 --selector "#main"
 node scripts/read-active-tab.js --preset chat-audit --selector "body" --message-regex ".*"
 ```
 

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "Grais Tab Webdata Reader"
-  short_description: "Help with Grais Tab Webdata Reader tasks"
+  display_name: "Agent Browser Relay Reader"
+  short_description: "Help with Agent Browser Relay tab-reader tasks"

--- a/extension/background.js
+++ b/extension/background.js
@@ -171,7 +171,7 @@ function refreshTabIndicator(tabId) {
     setBadge(normalizedTabId, 'on')
     void chrome.action.setTitle({
       tabId: normalizedTabId,
-      title: 'Grais Debugger Browser Relay: attached (click to detach)',
+      title: 'Agent Browser Relay: attached (click to detach)',
     })
     return
   }
@@ -179,7 +179,7 @@ function refreshTabIndicator(tabId) {
     setBadge(normalizedTabId, 'connecting')
     void chrome.action.setTitle({
       tabId: normalizedTabId,
-      title: 'Grais Debugger Browser Relay: attaching to active tab…',
+      title: 'Agent Browser Relay: attaching to active tab…',
     })
   }
 }
@@ -193,7 +193,7 @@ function sleep(ms) {
 function dbg(...args) {
   if (!DEBUG_LOG) return
   try {
-    console.log('[Grais Debugger]', ...args)
+    console.log('[Agent Browser Relay]', ...args)
   } catch {
     // no-op
   }
@@ -470,7 +470,7 @@ function onRelayClosed(reason) {
     setBadge(tabId, 'connecting')
     void chrome.action.setTitle({
       tabId,
-      title: 'Grais Debugger Browser Relay: disconnected (click to re-attach)',
+      title: 'Agent Browser Relay: disconnected (click to re-attach)',
     })
   }
   tabs.clear()
@@ -748,7 +748,7 @@ async function attachTab(tabId, opts = {}) {
   tabBySession.set(sessionId, tabId)
     void chrome.action.setTitle({
       tabId,
-      title: 'Grais Debugger Browser Relay: attached (click to detach)',
+      title: 'Agent Browser Relay: attached (click to detach)',
     })
 
   if (!opts.skipAttachedEvent) {
@@ -775,7 +775,7 @@ async function ensureActiveTabAttachedFromRelay({ force = false, tabId } = {}) {
   dbg('ensureActiveTabAttachedFromRelay.start', { force, tabId })
   const targetTabId = Number.isInteger(tabId) ? tabId : await resolvePinnedTabId()
   if (!targetTabId) {
-    throw new Error('No pinned tab selected. Click Grais Debugger on the target tab to attach.')
+    throw new Error('No pinned tab selected. Click Agent Browser Relay on the target tab to attach.')
   }
   await ensureRelayConnection(targetTabId)
   manualDetachTabs.delete(targetTabId)
@@ -801,7 +801,7 @@ async function ensureActiveTabAttachedFromRelay({ force = false, tabId } = {}) {
     setBadge(targetTabId, 'connecting')
     void chrome.action.setTitle({
       tabId: targetTabId,
-      title: 'Grais Debugger Browser Relay: attaching to active tab…',
+      title: 'Agent Browser Relay: attaching to active tab…',
     })
     try {
       await attachTab(targetTabId, { skipAttachedEvent: true })
@@ -858,12 +858,12 @@ async function detachTab(tabId, reason) {
   setBadge(tabId, 'off')
     void chrome.action.setTitle({
       tabId,
-      title: 'Grais Debugger Browser Relay (click to attach/detach)',
+      title: 'Agent Browser Relay (click to attach/detach)',
     })
 }
 
 async function connectOrToggleForActiveTab(tab) {
-  console.log('[Grais Debugger] toolbar icon clicked', {
+  console.log('[Agent Browser Relay] toolbar icon clicked', {
     clickedTabId: Number.isInteger(tab?.id) ? tab.id : null,
     clickedTabUrl: tab?.url || null,
     clickedWindowId: Number.isInteger(tab?.windowId) ? tab.windowId : null,
@@ -892,7 +892,7 @@ async function connectOrToggleForActiveTab(tab) {
   setBadge(tabId, 'connecting')
     void chrome.action.setTitle({
       tabId,
-      title: 'Grais Debugger Browser Relay: connecting to local relay…',
+      title: 'Agent Browser Relay: connecting to local relay…',
     })
 
   try {
@@ -917,7 +917,7 @@ async function connectOrToggleForActiveTab(tab) {
     setBadge(tabId, 'error')
     void chrome.action.setTitle({
       tabId,
-      title: 'Grais Debugger Browser Relay: relay not running (open options for setup)',
+      title: 'Agent Browser Relay: relay not running (open options for setup)',
     })
     void maybeOpenHelpOnce()
     // Extra breadcrumbs in chrome://extensions service worker logs.
@@ -968,7 +968,7 @@ async function handleForwardCdpCommand(msg) {
     if (!explicitTabId) {
       return {
         ok: false,
-        error: 'No pinned tab selected. Click Grais Debugger on the target tab to attach.',
+        error: 'No pinned tab selected. Click Agent Browser Relay on the target tab to attach.',
       }
     }
     const tab = await chrome.tabs.get(explicitTabId).catch(() => null)

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Grais Debugger Browser Relay",
+  "name": "Agent Browser Relay",
   "version": "0.1.3",
-  "description": "Attach Grais Debugger to your existing Chrome tab via a local CDP relay server.",
+  "description": "Attach Agent Browser Relay to your existing Chrome tab via a local CDP relay server.",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",
@@ -13,7 +13,7 @@
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {
-    "default_title": "Grais Debugger Browser Relay",
+    "default_title": "Agent Browser Relay",
     "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/icon16.png",

--- a/extension/options.html
+++ b/extension/options.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Grais powertools</title>
+    <title>Agent Browser Relay</title>
     <style>
       :root {
         color-scheme: light dark;
@@ -156,8 +156,8 @@
       <header>
         <div class="logo" aria-hidden="true"></div>
         <div>
-          <h1>Grais powertools</h1>
-          <p class="subtitle">Grais debugger relay helpers and status.</p>
+          <h1>Agent Browser Relay</h1>
+          <p class="subtitle">Agent Browser Relay helpers and status.</p>
         </div>
       </header>
 
@@ -166,10 +166,10 @@
           <h2>Getting started</h2>
           <p>
             If you see a red <code>!</code> badge on the extension icon, the relay server is not reachable.
-            Start the Grais relay on this machine, open the target tab, then use the toolbar popup to attach.
+            Start Agent Browser Relay on this machine, open the target tab, then use the toolbar popup to attach.
           </p>
           <p>
-            Full guide (install, remote Gateway, security): <a href="https://docs.gra.is/tools/chrome-extension" target="_blank" rel="noreferrer">docs.gra.is/tools/chrome-extension</a>
+            Full guide (install and usage): <a href="https://github.com/Mindgames/Agent-browser-relay" target="_blank" rel="noreferrer">github.com/Mindgames/Agent-browser-relay</a>
           </p>
         </div>
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -18,7 +18,7 @@ async function checkRelayReachable(port) {
   } catch {
     setStatus(
       'error',
-      `Relay not reachable at ${url}. Start the Grais Debugger browser relay on this machine, then use the toolbar popup again.`,
+      `Relay not reachable at ${url}. Start Agent Browser Relay on this machine, then use the toolbar popup again.`,
     )
   } finally {
     clearTimeout(t)

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Grais Browser Relay</title>
+    <title>Agent Browser Relay</title>
     <style>
       :root {
         color-scheme: light dark;
@@ -154,7 +154,7 @@
   <body>
     <main>
       <section class="panel">
-        <h1>Grais Browser Relay</h1>
+        <h1>Agent Browser Relay</h1>
         <div id="activeTab" class="muted tiny"></div>
         <div id="stateRow" class="muted tiny"></div>
         <div class="row">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "grais-debugger-relay",
+  "name": "agent-browser-relay",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "grais-debugger-relay",
+      "name": "agent-browser-relay",
       "version": "0.1.0",
       "dependencies": {
         "ws": "^8.18.2"
       },
       "bin": {
-        "grais-debugger-relay": "relay-server.js"
+        "agent-browser-relay": "relay-server.js"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "grais-debugger-relay",
+  "name": "agent-browser-relay",
   "private": true,
   "version": "0.1.0",
   "bin": {
-    "grais-debugger-relay": "relay-server.js"
+    "agent-browser-relay": "relay-server.js"
   },
   "scripts": {
     "lint": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",

--- a/relay-server.js
+++ b/relay-server.js
@@ -66,9 +66,9 @@ function initializePorts(ports) {
       .then(() => {
         const portsLabel = sortedPorts.join(', ')
         if (sortedPorts.length > 1) {
-          console.log(`Grais Debugger relay listening on ports: ${portsLabel} (shared relay hub)`)
+          console.log(`Agent Browser Relay listening on ports: ${portsLabel} (shared relay hub)`)
         } else {
-          console.log(`Grais Debugger relay listening on ws://${host}:${sortedPorts[0]}/extension`)
+          console.log(`Agent Browser Relay listening on ws://${host}:${sortedPorts[0]}/extension`)
         }
         console.log(`Health endpoint: http://${host}:${sortedPorts[0]}/`)
         if (maxRuntimeMs > 0) {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,9 +4,31 @@ set -euo pipefail
 SKILL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$SKILL_ROOT"
 
-RELAY_HOST="${GRAIS_RELAY_HOST:-127.0.0.1}"
-RELAY_PORT="${GRAIS_RELAY_PORT:-18793}"
-ATTACH_TIMEOUT_MS="${GRAIS_ATTACH_TIMEOUT_MS:-120000}"
+RELAY_HOST="127.0.0.1"
+RELAY_PORT="18793"
+ATTACH_TIMEOUT_MS="120000"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      RELAY_HOST="${2:-$RELAY_HOST}"
+      shift 2
+      ;;
+    --port)
+      RELAY_PORT="${2:-$RELAY_PORT}"
+      shift 2
+      ;;
+    --attach-timeout-ms)
+      ATTACH_TIMEOUT_MS="${2:-$ATTACH_TIMEOUT_MS}"
+      shift 2
+      ;;
+    *)
+      echo "[preflight] Unknown argument: $1" >&2
+      echo "[preflight] Usage: ./scripts/preflight.sh [--host 127.0.0.1] [--port 18793] [--attach-timeout-ms 120000]" >&2
+      exit 1
+      ;;
+  esac
+done
 RELAY_STATUS_URL="http://${RELAY_HOST}:${RELAY_PORT}/status"
 
 echo "[preflight] checking relay status: ${RELAY_STATUS_URL}"

--- a/scripts/read-active-tab.js
+++ b/scripts/read-active-tab.js
@@ -31,8 +31,8 @@ if (options.help) {
   process.exit(0)
 }
 
-const relayHost = String(options.host || process.env.GRAIS_RELAY_HOST || DEFAULT_HOST).trim() || DEFAULT_HOST
-const relayPort = parsePositiveInt(options.port || process.env.GRAIS_RELAY_PORT, DEFAULT_PORT, 'port')
+const relayHost = String(options.host || DEFAULT_HOST).trim() || DEFAULT_HOST
+const relayPort = parsePositiveInt(options.port, DEFAULT_PORT, 'port')
 const relayStatusUrl = `http://${relayHost}:${relayPort}/status`
 const relayWebSocketUrl = `ws://${relayHost}:${relayPort}/extension`
 const timeoutMs = parsePositiveInt(options.timeout, DEFAULT_TIMEOUT_MS, 'timeout')
@@ -1415,7 +1415,7 @@ async function assertRelayConnectionReady() {
   if (!targetStatus || !targetStatus.extensionConnected) {
     assertNoPortMismatch(snapshot)
     throw new Error(
-      `Relay is reachable (${relayStatusUrl}) but extension is not connected. Open the target tab and click Grais Debugger.`,
+      `Relay is reachable (${relayStatusUrl}) but extension is not connected. Open the target tab and click Agent Browser Relay.`,
     )
   }
 }
@@ -1628,7 +1628,7 @@ async function waitForAttachmentReady(options = {}) {
   throw new Error(
     [
       `Timed out waiting for active tab attachment (${timeoutMs}ms) at ${relayStatusUrl}.`,
-      'Keep the target tab active in Chrome and click the Grais Debugger icon to attach.',
+      'Keep the target tab active in Chrome and click the Agent Browser Relay icon to attach.',
       ...(lastFailure ? [`Last observed check state: ${JSON.stringify(lastFailure)}`] : []),
     ].join(' '),
   )

--- a/scripts/relay-manager.js
+++ b/scripts/relay-manager.js
@@ -5,8 +5,8 @@ const path = require('node:path')
 const http = require('node:http')
 const { spawn } = require('node:child_process')
 
-const DEFAULT_HOST = String(process.env.GRAIS_RELAY_HOST || '127.0.0.1').trim() || '127.0.0.1'
-const DEFAULT_PORT = parsePort(process.env.GRAIS_RELAY_PORT, 18793)
+const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_PORT = 18793
 const DEFAULT_TIMEOUT_MS = 12000
 const DEFAULT_START_TIMEOUT_MS = 10000
 const DEFAULT_START_POLL_MS = 250
@@ -478,7 +478,8 @@ function parseArgs(argv) {
 
 function printUsage() {
   console.log(`Usage:
-  Relay manager reads GRAIS_RELAY_HOST / GRAIS_RELAY_PORT by default.
+  Relay manager uses in-code defaults (${DEFAULT_HOST}:${DEFAULT_PORT}).
+  Override with --host / --port / --ports when needed.
   node scripts/relay-manager.js start [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--ports ${DEFAULT_PORT},18794] [--timeout 12000] [--status-timeout-ms 1200] [--start-timeout-ms 10000] [--auto-stop-ms 7200000]
   node scripts/relay-manager.js status [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--ports ${DEFAULT_PORT},18794] [--status-timeout-ms 1200] [--all]
   node scripts/relay-manager.js ports [--host ${DEFAULT_HOST}] --action add|remove --ports ${DEFAULT_PORT},18794 [--status-timeout-ms 1200]

--- a/scripts/relay-service.js
+++ b/scripts/relay-service.js
@@ -18,8 +18,8 @@ const DEFAULT_READY_CHECK_DELAY_MS = 250
 
 const REPO_ROOT = path.resolve(fs.realpathSync(__dirname), '..')
 const RELAY_SERVER_PATH = path.join(REPO_ROOT, 'relay-server.js')
-const RELAY_HOST_DEFAULT = parseHost(process.env.GRAIS_RELAY_HOST || DEFAULT_HOST)
-const RELAY_PORT_DEFAULT = parsePositiveInt(process.env.GRAIS_RELAY_PORT || String(DEFAULT_PORT), DEFAULT_PORT, 'relay port')
+const RELAY_HOST_DEFAULT = parseHost(DEFAULT_HOST)
+const RELAY_PORT_DEFAULT = DEFAULT_PORT
 
 const args = parseArgs(process.argv.slice(2))
 const command = args.command
@@ -362,7 +362,7 @@ function ensureServiceFile() {
 
   if (PLATFORM === 'linux') {
     const unit = `[Unit]
-Description=Grais Debugger Relay
+Description=Agent Browser Relay
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
## Summary
- Rebrand user-facing extension/UI/docs naming to **Agent Browser Relay**.
- Remove environment-variable based relay default configuration from runtime paths.
- Keep code-level defaults and document explicit per-command override flags.

## Why this change
- The extension still surfaced old branding in manifest/popup/options/tooltips, which created visible inconsistency.
- Setup guidance relied on `export`-based defaults that are less reliable than in-code defaults plus explicit flags.
- A single naming/config model reduces setup friction and confusion.

## What changed
- Branding cleanup (user-facing strings):
  - Updated extension manifest name/title/description.
  - Updated popup/options UI headings and helper text.
  - Updated background tooltip/error/log labels shown to users.
  - Updated README/SKILL/AGENTS wording where user-facing brand text appeared.
  - Updated agent interface display labels.
- Config/default model cleanup:
  - `scripts/read-active-tab.js` now uses in-code defaults (`127.0.0.1:18793`) unless CLI flags are passed.
  - `scripts/relay-manager.js` and `scripts/relay-service.js` now use in-code host/port defaults.
  - `scripts/preflight.sh` now uses direct defaults and supports explicit flags:
    - `--host`
    - `--port`
    - `--attach-timeout-ms`
  - README/SKILL/AGENTS examples updated to direct defaults and flag-based overrides (no `export GRAIS_*` setup).
- Package metadata:
  - Renamed package/bin identifiers from `grais-debugger-relay` to `agent-browser-relay`.

## Files changed
- `AGENTS.md`
- `README.md`
- `SKILL.md`
- `agents/openai.yaml`
- `extension/background.js`
- `extension/manifest.json`
- `extension/options.html`
- `extension/options.js`
- `extension/popup.html`
- `package-lock.json`
- `package.json`
- `relay-server.js`
- `scripts/preflight.sh`
- `scripts/read-active-tab.js`
- `scripts/relay-manager.js`
- `scripts/relay-service.js`

## QA / Testing
- Command: `pnpm lint` — Result: passed.
- Command: `pnpm knip` — Result: passed (`knip` intentionally reports "not configured ... skipped").
- Command: `pnpm build` — Result: passed.
- Command: `bash -n scripts/preflight.sh` — Result: passed.
- Command: `rg -n "Grais Debugger|Grais Browser Relay|Grais powertools|Start the Grais relay|click Grais Debugger|Grais Debugger icon" -S --glob '!node_modules/**'` — Result: no matches.

## Risks and impacts
- Low-to-moderate risk: broad string/docs changes across extension and docs, plus config-default behavior updates.
- Compatibility risk is mitigated by keeping internal relay protocol method names (`Grais.relay.*`, `Grais.debugger.*`) unchanged.

## Rollback plan
- Revert this commit on the branch.
- Reload extension in `chrome://extensions` to return to previous labels/behavior.

## Related issues
- No confirmed issue number was provided.

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
