### PR TITLE
feat(extension): add tab spawn toggle and options polish

### DIFF
--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "Agent Browser Relay Reader"
+  display_name: "Agent Browser Relay"
   short_description: "Help with Agent Browser Relay tab-reader tasks"

--- a/extension/background.js
+++ b/extension/background.js
@@ -11,6 +11,7 @@ const FORWARD_COMMAND_TIMEOUT_MS = 10000
 const DEBUG_LOG = true
 const ALLOW_FOREGROUND_ACTIVATE_TARGET = false
 const RELAY_PORT_BY_TAB_KEY = 'relayPortByTab'
+const ALLOW_TARGET_CREATE_KEY = 'allowTargetCreate'
 
 const BADGE = {
   on: { text: 'ON', color: '#16A34A' },
@@ -43,6 +44,8 @@ let debuggerListenersInstalled = false
 let userAttachmentEnabled = false
 /** @type {number|null} */
 let userPinnedTabId = null
+/** @type {boolean} */
+let allowTargetCreate = false
 
 let nextSession = 1
 let currentRelayPort = DEFAULT_PORT
@@ -143,6 +146,16 @@ async function setPinnedTabPref(tabId) {
     return
   }
   await chrome.storage.local.set({ userPinnedTabId: normalized })
+}
+
+async function getAllowTargetCreatePref() {
+  const stored = await chrome.storage.local.get([ALLOW_TARGET_CREATE_KEY])
+  return stored[ALLOW_TARGET_CREATE_KEY] === true
+}
+
+async function setAllowTargetCreatePref(enabled) {
+  allowTargetCreate = Boolean(enabled)
+  await chrome.storage.local.set({ [ALLOW_TARGET_CREATE_KEY]: allowTargetCreate })
 }
 
 async function disableAttachmentState() {
@@ -1055,6 +1068,9 @@ async function handleForwardCdpCommand(msg) {
     }
 
     if (method === 'Target.createTarget') {
+      if (!allowTargetCreate) {
+        throw new Error('Target.createTarget is disabled. Enable "Allow agent to open new background tabs" in the popup.')
+      }
       const url = typeof params?.url === 'string' ? params.url : 'about:blank'
       dbg('handleForwardCdpCommand.targetCreate', { requestedUrl: url })
       const tab = await chrome.tabs.create({ url, active: false })
@@ -1130,12 +1146,14 @@ async function handleForwardCdpCommand(msg) {
 
 async function initializeAttachmentState() {
   try {
-    const [shouldBeAttached, pinnedTabPref] = await Promise.all([
+    const [shouldBeAttached, pinnedTabPref, allowTargetCreatePref] = await Promise.all([
       getUserAttachmentPref(),
       getPinnedTabPref(),
+      getAllowTargetCreatePref(),
     ])
     userAttachmentEnabled = Boolean(shouldBeAttached)
     userPinnedTabId = pinnedTabPref
+    allowTargetCreate = Boolean(allowTargetCreatePref)
     if (!shouldBeAttached) return
     if (!Number.isInteger(userPinnedTabId)) {
       await disableAttachmentState()
@@ -1228,6 +1246,7 @@ chrome.runtime.onInstalled.addListener(() => {
   void Promise.allSettled([
     setUserAttachmentPref(false),
     setPinnedTabPref(null),
+    setAllowTargetCreatePref(false),
   ])
   // Useful: first-time instructions.
   void chrome.runtime.openOptionsPage()
@@ -1277,6 +1296,7 @@ async function getPopupState(tabId, includeAllTabs = true) {
     mappedPort: Number.isInteger(mappedPort) ? mappedPort : null,
     effectivePort: Number.isInteger(effectivePort) ? effectivePort : defaultPort,
     userAttachmentEnabled,
+    allowTargetCreate,
     activeTabState: requestedTabId && tabs.get(requestedTabId)?.state ? tabs.get(requestedTabId).state : null,
     connectedTabs,
   }
@@ -1330,6 +1350,14 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         const state = await getPopupState(tabId, true)
         const wasAttached = state.activeTabState === 'connected'
         sendResponse({ ok: true, attached: wasAttached, ...state })
+        return
+      }
+
+      if (message.type === 'grais.popup.setTargetCreateEnabled') {
+        const enabled = message.enabled === true
+        await setAllowTargetCreatePref(enabled)
+        const state = await getPopupState(message.tabId, true)
+        sendResponse({ ok: true, ...state })
         return
       }
 

--- a/extension/options.html
+++ b/extension/options.html
@@ -11,7 +11,6 @@
         --panel: color-mix(in oklab, canvas 92%, canvasText 8%);
         --border: color-mix(in oklab, canvasText 18%, transparent);
         --muted: color-mix(in oklab, canvasText 70%, transparent);
-        --shadow: 0 10px 30px color-mix(in oklab, canvasText 18%, transparent);
         font-family: ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Rounded",
           "SF Pro Display", "Segoe UI", sans-serif;
         line-height: 1.4;
@@ -36,21 +35,6 @@
         gap: 12px;
         margin-bottom: 18px;
       }
-      .logo {
-        width: 44px;
-        height: 44px;
-        border-radius: 14px;
-        background: color-mix(in oklab, var(--accent) 18%, transparent);
-        border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent);
-        box-shadow: var(--shadow);
-        display: grid;
-        place-items: center;
-      }
-      .logo img {
-        width: 28px;
-        height: 28px;
-        image-rendering: pixelated;
-      }
       h1 {
         font-size: 20px;
         margin: 0;
@@ -68,10 +52,9 @@
       }
       .card {
         background: var(--panel);
-        border: 1px solid var(--border);
+        border: 4px solid var(--border);
         border-radius: 16px;
         padding: 16px;
-        box-shadow: var(--shadow);
       }
       .card h2 {
         margin: 0 0 10px 0;
@@ -134,6 +117,19 @@
         font-family: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", monospace;
         font-size: 12px;
       }
+      pre {
+        margin: 10px 0 0 0;
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: color-mix(in oklab, canvas 92%, canvasText 8%);
+        overflow-x: auto;
+      }
+      pre code {
+        font-size: 12px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
       a {
         color: color-mix(in oklab, var(--accent) 85%, canvasText 15%);
       }
@@ -154,7 +150,6 @@
   <body>
     <div class="wrap">
       <header>
-        <div class="logo" aria-hidden="true"></div>
         <div>
           <h1>Agent Browser Relay</h1>
           <p class="subtitle">Agent Browser Relay helpers and status.</p>
@@ -165,9 +160,9 @@
         <div class="card">
           <h2>Getting started</h2>
           <p>
-            If you see a red <code>!</code> badge on the extension icon, the relay server is not reachable.
-            Start Agent Browser Relay on this machine, open the target tab, then use the toolbar popup to attach.
+            Send this prompt to your agent:
           </p>
+          <pre><code>Use Agent Browser Relay on my current Chrome tab and return a concise summary with the most important links.</code></pre>
           <p>
             Full guide (install and usage): <a href="https://github.com/Mindgames/Agent-browser-relay" target="_blank" rel="noreferrer">github.com/Mindgames/Agent-browser-relay</a>
           </p>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -58,7 +58,7 @@
         align-items: center;
         margin: 6px 0;
       }
-      input,
+      input:not([type='checkbox']),
       select,
       button {
         border-radius: 0;
@@ -141,6 +141,24 @@
         display: grid;
         gap: 6px;
       }
+      .toggleRow {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        margin-top: 8px;
+      }
+      .toggleRow input[type='checkbox'] {
+        width: 14px;
+        height: 14px;
+        margin-top: 2px;
+        accent-color: var(--accent);
+      }
+      .toggleLabel {
+        display: block;
+        margin: 0;
+        font-size: 12px;
+        line-height: 1.25;
+      }
       a {
         color: color-mix(in oklab, var(--accent) 85%, canvasText 15%);
         font-size: 11px;
@@ -176,6 +194,13 @@
         </div>
         <div class="small">
           Choose a relay port for this tab, then click <strong>Apply</strong>.
+        </div>
+        <div class="toggleRow">
+          <input id="allowCreateTarget" type="checkbox" />
+          <label for="allowCreateTarget" class="toggleLabel">
+            Allow agent to open new background tabs
+            <span class="meta">Controls CDP <code>Target.createTarget</code> requests (off by default).</span>
+          </label>
         </div>
         <div class="row toolbar">
           <button id="attach" type="button">Attach</button>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -9,6 +9,7 @@ const savePortButton = document.getElementById('savePort')
 const clearPortButton = document.getElementById('clearPort')
 const attachButton = document.getElementById('attach')
 const refreshButton = document.getElementById('refresh')
+const allowCreateTargetToggle = document.getElementById('allowCreateTarget')
 
 function setStatus(message, kind = 'ok') {
   if (!statusEl) return
@@ -126,6 +127,9 @@ function renderAttachmentControl(state) {
   activeTabEl.textContent = state.activeTab ? tabLabel(state.activeTab) : `Current tab: ${state.requestedTabId || 'unknown'}`
   defaultPortEl.textContent = `default ${state.defaultPort}`
   connectedPortEl.textContent = `active relay ${state.relayPortConnected}`
+  if (allowCreateTargetToggle) {
+    allowCreateTargetToggle.checked = Boolean(state.allowTargetCreate)
+  }
 
   const preferredPort = Number.isInteger(state.mappedPort)
     ? state.mappedPort
@@ -211,9 +215,32 @@ async function onToggleAttach() {
   }
 }
 
+async function onToggleAllowCreateTarget() {
+  if (!allowCreateTargetToggle) return
+  const enabled = allowCreateTargetToggle.checked === true
+  try {
+    const tabId = await getCurrentActiveTabId()
+    const response = await sendMessage({
+      type: 'grais.popup.setTargetCreateEnabled',
+      enabled,
+      tabId,
+    })
+    renderAttachmentControl(response)
+    renderConnectedTabs(response)
+    setStatus(
+      response.allowTargetCreate ? 'Agent new-tab spawn enabled' : 'Agent new-tab spawn disabled',
+      'ok',
+    )
+  } catch (err) {
+    allowCreateTargetToggle.checked = !enabled
+    setStatus(err.message || 'Failed to update setting', 'err')
+  }
+}
+
 refreshButton?.addEventListener('click', () => void refresh())
 savePortButton?.addEventListener('click', () => void onSavePort())
 clearPortButton?.addEventListener('click', () => void onClearPort())
 attachButton?.addEventListener('click', () => void onToggleAttach())
+allowCreateTargetToggle?.addEventListener('change', () => void onToggleAllowCreateTarget())
 
 void refresh()


### PR DESCRIPTION
## Summary
Add a safer relay-control toggle for agent-created tabs, simplify onboarding prompt copy, and clean up extension/skill naming.

## Why
- New-tab creation should be explicitly user-controlled in popup UI.
- Onboarding prompt should be concise and rely on skill instructions.
- Extension options UI requested a bolder border style without shadows.

## What changed
- Added popup toggle: **Allow agent to open new background tabs** (persisted in `chrome.storage.local`).
- Added background gate for `Target.createTarget`; returns explicit error when disabled.
- Updated options onboarding prompt to a single-sentence agent prompt.
- Removed card shadow on options page and switched card borders to `4px`.
- Renamed OpenAI skill display name from `Agent Browser Relay Reader` to `Agent Browser Relay`.

## How
- UI + state wiring in popup/background message flow (`grais.popup.setTargetCreateEnabled`).
- Runtime enforcement in `handleForwardCdpCommand` before `Target.createTarget` execution.
- Options page style/text updates in static HTML.

## Testing
- `pnpm lint` ✅
- `pnpm knip` ✅ (repo reports "not configured; skipped")
- `pnpm build` ✅

## Notes
- No issue number was derivable from branch name.

## Related issue
- None specified.

## Checklist
- [x] Lint/build checks pass
- [x] Changes pushed to branch
- [x] PR includes behavior + verification notes
