### PR TITLE
chore(agent-browser-relay): sync extension install/version flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ npx skills add Mindgames/Agent-browser-relay -g -y
 ```
 
 ### 2) Load the extension in Chrome (Developer mode)
-After install, the skill is available at:
+After install with the `skills` installer, the skill is available at:
 `~/.agents/skills/agent-browser-relay`
 
 1. Open `chrome://extensions`
 2. Enable **Developer mode**
 3. Click **Load unpacked**
 4. Select this folder:
-   `~/.agents/skills/agent-browser-relay/extension`
+   `~/agent-browser-relay/extension`
+
+`read-active-tab.js` keeps this folder synced on first run and prints the install path + version
+sync status as stderr hints, so humans do not need to find hidden folders.
 5. Pin the **Agent Browser Relay** toolbar icon
 
 ### 3) Attach tabs and allow broader tab control
@@ -75,8 +78,8 @@ This repo integrates with two different skill roots:
   - Canonical global skill path for this relay project.
 - `~/.claude/skills/agent-browser-relay`
   - Usually symlinked automatically by the `skills` installer when Claude Code is present.
-- `~/.agents/skills/agent-browser-relay/extension`
-  - Exact Chrome extension directory to load in Developer mode.
+- `~/agent-browser-relay/extension`
+  - Visible Chrome extension directory printed by the skill and safe for manual navigation in Chrome.
 
 Why this matters: installer-based setup gives a stable path and keeps Codex/Claude integrations consistent.
 
@@ -87,6 +90,16 @@ Why this matters: installer-based setup gives a stable path and keeps Codex/Clau
 - `scripts/relay-service.js`: global `launchd/systemd --user` service lifecycle.
 - `scripts/read-active-tab.js`: read/check CLI that prints JSON.
 - Relay tab leasing (`--tab-id`): isolates concurrent agents to specific tabs.
+- `scripts/extension-install-helper.js`: keeps a visible extension install folder in sync.
+
+## Capability library exposed to callers
+
+`read-active-tab.js` includes a machine-readable capability block in each JSON payload (`source.capabilities`), including:
+- CLI switches (`--check`, `--metadata`, `--screenshot`, `--expression`, presets, `--tab-id`, etc.)
+- Relay methods used by the client (`Grais.relay.*`)
+- Bridge methods (`Grais.debugger.*`)
+- Common CDP methods exposed for extraction and screenshots
+- Installed/observed extension version metadata (`source.extension`) so tooling can warn on mismatches and redirect humans to updates.
 
 ## Relay Endpoint Defaults
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,13 +15,7 @@ Defaults are set in code:
 - Attach timeout: `120000` ms
 Override per command with `--host`, `--port`, and `--attach-timeout-ms` when needed.
 
-1. Wire canonical skill path
-
-   ```bash
-   npm run codex:install
-   ```
-
-2. Install dependencies and start relay
+1. Install dependencies and start relay
 
    ```bash
    npm run relay:start -- --status-timeout-ms 3000
@@ -40,11 +34,11 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
    node scripts/relay-manager.js start --auto-stop-ms 0
    ```
 
-3. Load extension from the `extension/` subfolder in Chrome
+2. Load extension in Chrome
 
    - `chrome://extensions`
    - Enable developer mode
-   - Load unpacked from `~/.agents/skills/private/agent-browser-relay/extension`
+   - Load unpacked from `~/agent-browser-relay/extension` (this is the visible folder created by the skill helper)
 
 3. Attach the extension to the target tab (open toolbar popup and click attach)
 
@@ -114,6 +108,19 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
    ```
 
 ## Capabilities
+
+`read-active-tab.js` returns capability metadata in every successful payload under:
+
+`source.capabilities`
+
+Version compatibility checks are also included under `source.extension`:
+- `installedVersion`
+- `sourceVersion`
+- `relayVersion`
+- `observedExtensionVersion`
+- `versionMismatch`
+
+If a mismatch is detected, the command also prints a human-friendly update hint to stderr on every run.
 
 - `scripts/read-active-tab.js` default extraction: `url`, `title`, `text`, `links`, `metaDescription`.
 - Relay session leases (`--tab-id`) for concurrent agent isolation per tab on one relay port.

--- a/extension/background.js
+++ b/extension/background.js
@@ -12,6 +12,26 @@ const DEBUG_LOG = true
 const ALLOW_FOREGROUND_ACTIVATE_TARGET = false
 const RELAY_PORT_BY_TAB_KEY = 'relayPortByTab'
 const ALLOW_TARGET_CREATE_KEY = 'allowTargetCreate'
+const EXTENSION_CAPABILITIES = Object.freeze({
+  bridgeMethods: [
+    'Grais.debugger.ensureActiveTab',
+    'Grais.debugger.attachTab',
+    'Grais.debugger.getActiveTabMetadata',
+    'Grais.relay.openSession',
+    'Grais.relay.closeSession',
+    'Grais.relay.claimTab',
+    'Grais.relay.releaseTab',
+  ],
+  cdpMethods: [
+    'Runtime.enable',
+    'Runtime.evaluate',
+    'Page.captureScreenshot',
+    'Target.createTarget',
+    'Target.closeTarget',
+    'Target.activateTarget',
+  ],
+  presets: ['default', 'whatsapp', 'whatsapp-messages', 'wa', 'chat-audit', 'chat'],
+})
 
 const BADGE = {
   on: { text: 'ON', color: '#16A34A' },
@@ -525,6 +545,7 @@ async function sendRelayHeartbeat() {
   if (!relayWs || relayWs.readyState !== WebSocket.OPEN) return
   const activeTab = await buildActiveHeartbeatTab()
   const attachedTabs = await buildAttachedHeartbeatTabs()
+  const manifest = typeof chrome?.runtime?.getManifest === 'function' ? chrome.runtime.getManifest() : null
   refreshTabIndicator(activeTab?.tabId)
   const payload = {
     method: 'Grais.extensionHeartbeat',
@@ -534,6 +555,9 @@ async function sendRelayHeartbeat() {
     status: userAttachmentEnabled ? 'ON' : 'OFF',
     activeTab,
     attachedTabs,
+    extensionVersion: manifest && typeof manifest.version === 'string' ? manifest.version : null,
+    extensionName: manifest && typeof manifest.name === 'string' ? manifest.name : null,
+    extensionCapabilities: EXTENSION_CAPABILITIES,
   }
   sendToRelay(payload)
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent Browser Relay",
-  "version": "0.1.3",
+  "version": "0.0.6",
   "description": "Attach Agent Browser Relay to your existing Chrome tab via a local CDP relay server.",
   "icons": {
     "16": "icons/icon16.png",
@@ -9,9 +9,20 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage"],
-  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
-  "background": { "service_worker": "background.js", "type": "module" },
+  "permissions": [
+    "debugger",
+    "tabs",
+    "activeTab",
+    "storage"
+  ],
+  "host_permissions": [
+    "http://127.0.0.1/*",
+    "http://localhost/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
   "action": {
     "default_title": "Agent Browser Relay",
     "default_popup": "popup.html",
@@ -22,5 +33,8 @@
       "128": "icons/icon128.png"
     }
   },
-  "options_ui": { "page": "options.html", "open_in_tab": true }
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,1 @@
+../package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-browser-relay",
-  "version": "0.1.0",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-browser-relay",
-      "version": "0.1.0",
+      "version": "0.0.6",
       "dependencies": {
         "ws": "^8.18.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "agent-browser-relay",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.6",
   "bin": {
     "agent-browser-relay": "relay-server.js"
   },
   "scripts": {
+    "sync:extension-version": "node scripts/sync-extension-version.js",
     "lint": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",
     "knip": "node -e \"console.log('knip: not configured for this repository; skipped')\"",
     "build": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",
@@ -29,7 +30,13 @@
     "relay:global:update": "node scripts/relay-service.js restart",
     "relay:global:status": "node scripts/relay-service.js status",
     "codex:install": "bash scripts/codex-skill-link.sh",
-    "codex:install:check": "bash scripts/codex-skill-link.sh --check"
+    "codex:install:check": "bash scripts/codex-skill-link.sh --check",
+    "preversion": "node scripts/sync-extension-version.js",
+    "version": "node scripts/sync-extension-version.js",
+    "postversion": "git push && git push --tags",
+    "release:patch": "pnpm version patch",
+    "release:minor": "pnpm version minor",
+    "release:major": "pnpm version major"
   },
   "dependencies": {
     "ws": "^8.18.2"

--- a/relay-server.js
+++ b/relay-server.js
@@ -139,6 +139,12 @@ function summarizePortState(state) {
       : [],
     tabLeases: summarizeTabLeases(state),
     lastHeartbeatTs: state.extensionHeartbeatState?.ts || null,
+    extensionVersion: state.extensionHeartbeatState?.extensionVersion || null,
+    extensionName: state.extensionHeartbeatState?.extensionName || null,
+      extensionCapabilities:
+        state.extensionHeartbeatState?.extensionCapabilities && typeof state.extensionHeartbeatState.extensionCapabilities === 'object'
+          ? state.extensionHeartbeatState.extensionCapabilities
+          : null,
   }
 }
 
@@ -160,6 +166,12 @@ function getSinglePortStatus(state) {
       ? state.extensionHeartbeatState.attachedTabs
       : [],
     tabLeases: summarizeTabLeases(state),
+    extensionVersion: state.extensionHeartbeatState?.extensionVersion || null,
+    extensionName: state.extensionHeartbeatState?.extensionName || null,
+    extensionCapabilities:
+      state.extensionHeartbeatState?.extensionCapabilities && typeof state.extensionHeartbeatState.extensionCapabilities === 'object'
+        ? state.extensionHeartbeatState.extensionCapabilities
+        : null,
   }
 }
 
@@ -669,6 +681,10 @@ function onExtensionMessage(msg, socket, state) {
         : [],
       state: String(msg.state || 'attached'),
       status: String(msg.status || ''),
+      extensionVersion: typeof msg.extensionVersion === 'string' ? msg.extensionVersion : null,
+      extensionName: typeof msg.extensionName === 'string' ? msg.extensionName : null,
+      extensionCapabilities:
+        msg.extensionCapabilities && typeof msg.extensionCapabilities === 'object' ? msg.extensionCapabilities : null,
     }
     refreshExtensionSessionMap(state)
     return

--- a/scripts/extension-install-helper.js
+++ b/scripts/extension-install-helper.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const REPO_ROOT = path.resolve(__dirname, '..')
+const SOURCE_EXTENSION_PATH = path.join(REPO_ROOT, 'extension')
+const SOURCE_PACKAGE_PATH = path.join(REPO_ROOT, 'package.json')
+
+const VISIBLE_ROOT = path.join(os.homedir(), 'agent-browser-relay')
+const VISIBLE_EXTENSION_PATH = path.join(VISIBLE_ROOT, 'extension')
+const VISIBLE_STATE_PATH = path.join(VISIBLE_ROOT, 'extension-install-state.json')
+
+const PROJECT_URL = 'https://github.com/Mindgames/agent-browser-relay'
+const PROJECT_RELEASES_URL = 'https://github.com/Mindgames/agent-browser-relay/releases/latest'
+
+const PROMPT_COOLDOWN_MS = 24 * 60 * 60 * 1000
+
+function readJson(filePath, fallback = null) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return fallback
+  }
+}
+
+function readManifestVersion(directory) {
+  const manifest = readJson(path.join(directory, 'manifest.json'), null)
+  const version = typeof manifest?.version === 'string' ? manifest.version.trim() : ''
+  return version.length ? version : null
+}
+
+function readPackageVersion() {
+  const pkg = readJson(SOURCE_PACKAGE_PATH, null)
+  const version = typeof pkg?.version === 'string' ? pkg.version.trim() : ''
+  return version.length ? version : null
+}
+
+function readInstallState() {
+  return readJson(VISIBLE_STATE_PATH, {})
+}
+
+function writeInstallState(state) {
+  try {
+    fs.mkdirSync(VISIBLE_ROOT, { recursive: true })
+    fs.writeFileSync(VISIBLE_STATE_PATH, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+  } catch {
+    // best effort only
+  }
+}
+
+function refreshInstallBundle(log = () => {}) {
+  const sourceVersion = readManifestVersion(SOURCE_EXTENSION_PATH)
+  const relayVersion = readPackageVersion()
+  const state = readInstallState()
+  const now = Date.now()
+
+  let installedVersion = readManifestVersion(VISIBLE_EXTENSION_PATH)
+  let updated = false
+
+  if (!sourceVersion) {
+    return {
+      ok: false,
+      path: VISIBLE_EXTENSION_PATH,
+      installedVersion,
+      sourceVersion,
+      relayVersion,
+      updated,
+      firstRun: false,
+      versionMismatch: false,
+      sourceMissing: true,
+    }
+  }
+
+  if (!installedVersion || installedVersion !== sourceVersion) {
+    try {
+      fs.mkdirSync(VISIBLE_ROOT, { recursive: true })
+      fs.rmSync(VISIBLE_EXTENSION_PATH, { recursive: true, force: true })
+      fs.cpSync(SOURCE_EXTENSION_PATH, VISIBLE_EXTENSION_PATH, {
+        recursive: true,
+      })
+      installedVersion = sourceVersion
+      updated = true
+    } catch {
+      return {
+        ok: false,
+        path: VISIBLE_EXTENSION_PATH,
+        installedVersion,
+        sourceVersion,
+        relayVersion,
+        updated,
+        firstRun: false,
+        versionMismatch: false,
+        sourceMissing: false,
+        copyFailed: true,
+      }
+    }
+  }
+
+  const installedMissing = Boolean(sourceVersion && !installedVersion)
+  const installedMismatch = Boolean(sourceVersion && installedVersion && sourceVersion !== installedVersion)
+  const relayMismatch = Boolean(relayVersion && installedVersion && relayVersion !== installedVersion)
+  const mismatch = Boolean(installedMissing || installedMismatch || relayMismatch)
+
+  const firstRun = state.firstRunSeen !== true
+  const lastHintAt = Number.isFinite(Number(state.lastHintAt)) ? Number(state.lastHintAt) : 0
+  const shouldPrintHint = mismatch || firstRun || (now - lastHintAt >= PROMPT_COOLDOWN_MS)
+
+  if (shouldPrintHint) {
+    log(`Chrome extension install path:`)
+    log(`  ${VISIBLE_EXTENSION_PATH}`)
+    log('Load this folder in chrome://extensions (Load unpacked).')
+    log('If the extension was previously loaded from another folder, repoint it here.')
+    log(`Extension version: ${installedVersion || 'unknown'}`)
+    log(`Relay package version: ${relayVersion || 'unknown'}`)
+    log(`Source manifest version: ${sourceVersion || 'unknown'}`)
+    if (mismatch) {
+      log('Version mismatch detected. Download newest extension bundle from:')
+      log(`  ${PROJECT_URL}`)
+      log(`Or update from releases:`)
+      log(`  ${PROJECT_RELEASES_URL}`)
+    }
+  }
+
+  writeInstallState({
+    lastHintAt: now,
+    firstRunSeen: true,
+    lastCheckedAt: now,
+    installedVersion,
+    relayVersion,
+    sourceVersion,
+    mismatch: mismatch,
+  })
+
+  return {
+    ok: true,
+    path: VISIBLE_EXTENSION_PATH,
+    installedVersion,
+    sourceVersion,
+    relayVersion,
+    updated,
+    firstRun,
+    versionMismatch: mismatch,
+    sourceMissing: false,
+  }
+}
+
+module.exports = {
+  refreshInstallBundle,
+}

--- a/scripts/read-active-tab.js
+++ b/scripts/read-active-tab.js
@@ -4,6 +4,47 @@
 const http = require('node:http')
 const fs = require('node:fs')
 const path = require('node:path')
+const { refreshInstallBundle } = require('./extension-install-helper')
+
+const PROJECT_RELEASES_URL = 'https://github.com/Mindgames/agent-browser-relay/releases/latest'
+
+const SKILL_CAPABILITIES = Object.freeze({
+  name: 'agent-browser-relay',
+  type: 'chrome-tab-read',
+  cliCapabilities: [
+    '--check',
+    '--check --wait-for-attach',
+    '--metadata',
+    '--screenshot',
+    '--screenshot-full-page',
+    '--expression',
+    '--preset',
+    '--tab-id',
+    '--wait-for-attach',
+  ],
+  relayMethods: [
+    'Grais.relay.openSession',
+    'Grais.relay.closeSession',
+    'Grais.relay.claimTab',
+    'Grais.relay.releaseTab',
+    'Grais.relay.listTabs',
+  ],
+  bridgeMethods: [
+    'Grais.debugger.ensureActiveTab',
+    'Grais.debugger.attachTab',
+    'Grais.debugger.getActiveTabMetadata',
+  ],
+  cdpMethods: [
+    'Runtime.evaluate',
+    'Runtime.enable',
+    'Page.captureScreenshot',
+    'Target.createTarget',
+    'Target.closeTarget',
+    'Target.activateTarget',
+  ],
+  presets: ['default', 'whatsapp', 'whatsapp-messages', 'wa', 'chat-audit', 'chat'],
+  extractorFields: ['url', 'title', 'text', 'links', 'metaDescription'],
+})
 
 const DEFAULT_PORT = 18793
 const DEFAULT_HOST = '127.0.0.1'
@@ -25,6 +66,18 @@ const PRESET_CHAT_AUDIT = 'chat-audit'
 
 const args = process.argv.slice(2)
 const options = parseArgs(args)
+
+let installBundle = {
+  ok: false,
+  path: null,
+  installedVersion: null,
+  sourceVersion: null,
+  relayVersion: null,
+  versionMismatch: false,
+  updated: false,
+  sourceMissing: false,
+  copyFailed: false,
+}
 
 if (options.help) {
   printUsage()
@@ -119,8 +172,15 @@ let activeSocket = false
 let rejectAllPending
 let relaySessionId = null
 let leasedTabId = Number.isInteger(requestedTabId) ? requestedTabId : null
+let relayStatusSnapshot = null
 
 function getRelaySource() {
+  const observedExtensionVersion = getObservedExtensionVersion()
+  const expectedExtensionVersion = installBundle.sourceVersion || installBundle.relayVersion || installBundle.installedVersion || null
+  const extensionMismatch =
+    typeof observedExtensionVersion === 'string' && typeof expectedExtensionVersion === 'string'
+      ? observedExtensionVersion !== expectedExtensionVersion
+      : false
   return {
     relayHost,
     relayPort,
@@ -128,7 +188,36 @@ function getRelaySource() {
     relayWebSocketUrl,
     relaySessionId,
     tabId: Number.isInteger(leasedTabId) ? leasedTabId : null,
+    capabilities: SKILL_CAPABILITIES,
+    extension: {
+      installPath: installBundle.path,
+      installedVersion: installBundle.installedVersion,
+      sourceVersion: installBundle.sourceVersion,
+      relayVersion: installBundle.relayVersion,
+      observedExtensionVersion,
+      expectedExtensionVersion,
+      observedCapabilities: relayStatusSnapshot?.extensionCapabilities
+        && typeof relayStatusSnapshot.extensionCapabilities === 'object'
+        ? relayStatusSnapshot.extensionCapabilities
+        : null,
+      observedVersionMismatch: extensionMismatch,
+      updated: Boolean(installBundle.updated),
+      versionMismatch: Boolean(installBundle.versionMismatch || extensionMismatch),
+      copyFailed: Boolean(installBundle.copyFailed),
+    },
   }
+}
+
+function getObservedExtensionVersion() {
+  if (!relayStatusSnapshot || typeof relayStatusSnapshot !== 'object') return null
+  if (typeof relayStatusSnapshot.extensionVersion === 'string') return relayStatusSnapshot.extensionVersion
+  if (!Array.isArray(relayStatusSnapshot.ports)) return null
+  for (const entry of relayStatusSnapshot.ports) {
+    if (!entry || typeof entry !== 'object') continue
+    if (Number(entry.port) !== relayPort) continue
+    if (typeof entry.extensionVersion === 'string') return entry.extensionVersion
+  }
+  return null
 }
 
 socket.addEventListener('open', () => {
@@ -1317,6 +1406,7 @@ function requestJson(url, timeoutMs = DEFAULT_STATUS_TIMEOUT_MS) {
 async function getRelayStatus(throwOnError = true) {
   try {
     const response = await requestJson(`${relayStatusUrl}?all=true`, statusTimeoutMs)
+    relayStatusSnapshot = typeof response === 'object' && response ? response : null
     return { ok: true, ...(typeof response === 'object' && response ? response : {}) }
   } catch (error) {
     if (throwOnError) {
@@ -1370,6 +1460,10 @@ function summarizeRelayPorts(statusPayload) {
         : null,
       activeTab: sanitizeStatusTab(raw.activeTab),
       attachedTabs: Array.isArray(raw.attachedTabs) ? raw.attachedTabs.map(sanitizeStatusTab).filter(Boolean) : [],
+      extensionVersion: typeof raw.extensionVersion === 'string' ? raw.extensionVersion : null,
+      extensionName: typeof raw.extensionName === 'string' ? raw.extensionName : null,
+      extensionCapabilities:
+        raw.extensionCapabilities && typeof raw.extensionCapabilities === 'object' ? raw.extensionCapabilities : null,
     })
   }
   ports.sort((a, b) => a.port - b.port)
@@ -1635,11 +1729,44 @@ async function waitForAttachmentReady(options = {}) {
 }
 
 async function main() {
+  try {
+    installBundle = refreshInstallBundle((message) => {
+      console.error(`[agent-browser-relay] ${message}`)
+    })
+  } catch {
+    installBundle = {
+      ok: false,
+      path: null,
+      installedVersion: null,
+      sourceVersion: null,
+      relayVersion: null,
+      versionMismatch: false,
+      updated: false,
+      sourceMissing: false,
+      copyFailed: true,
+    }
+  }
+
   const opened = await waitForSocket(4000)
   if (!opened) {
     console.error(`Failed to connect websocket ${wsUrl}`)
     process.exit(1)
   }
+
+  await getRelayStatus(false)
+    .then(() => {
+      const extension = getRelaySource().extension
+      if (!extension.versionMismatch) return
+      if (extension.observedExtensionVersion) {
+        console.error(
+          `[agent-browser-relay] Observed extension ${extension.observedExtensionVersion} does not match expected ${extension.expectedExtensionVersion}.`,
+        )
+      } else {
+        console.error(`[agent-browser-relay] Relay extension and relay package versions are out of sync.`)
+      }
+      console.error(`[agent-browser-relay] Download updated bundle from: ${PROJECT_RELEASES_URL}`)
+    })
+    .catch(() => {})
 
   rejectAllPending = (error) => {
     for (const [id, entry] of pending.entries()) {

--- a/scripts/sync-extension-version.js
+++ b/scripts/sync-extension-version.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ROOT_DIR = path.join(__dirname, '..')
+const ROOT_PACKAGE_PATH = path.join(ROOT_DIR, 'package.json')
+const EXTENSION_DIR = path.join(ROOT_DIR, 'extension')
+const EXTENSION_PACKAGE_PATH = path.join(EXTENSION_DIR, 'package.json')
+const EXTENSION_MANIFEST_PATH = path.join(EXTENSION_DIR, 'manifest.json')
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function ensureLinkedPackageFile() {
+  const desiredTarget = '../package.json'
+  let shouldLink = true
+
+  try {
+    const stat = fs.lstatSync(EXTENSION_PACKAGE_PATH)
+    if (stat.isSymbolicLink()) {
+      const currentTarget = fs.readlinkSync(EXTENSION_PACKAGE_PATH)
+      if (currentTarget === desiredTarget) {
+        shouldLink = false
+      } else {
+        fs.rmSync(EXTENSION_PACKAGE_PATH, { force: true })
+      }
+    } else {
+      fs.rmSync(EXTENSION_PACKAGE_PATH, { force: true })
+    }
+  } catch {
+    // target does not exist
+  }
+
+  if (shouldLink) {
+    fs.symlinkSync(desiredTarget, EXTENSION_PACKAGE_PATH, 'file')
+  }
+}
+
+function syncManifestVersion(version) {
+  const manifest = readJson(EXTENSION_MANIFEST_PATH)
+  if (manifest.version === version) {
+    return false
+  }
+
+  manifest.version = version
+  writeJson(EXTENSION_MANIFEST_PATH, manifest)
+  return true
+}
+
+function main() {
+  ensureLinkedPackageFile()
+
+  const rootPackage = readJson(ROOT_PACKAGE_PATH)
+  const nextVersion = String(rootPackage.version || '').trim()
+  if (!nextVersion) return
+
+  const changed = syncManifestVersion(nextVersion)
+  if (changed) {
+    process.stdout.write(`Synced extension manifest version to ${nextVersion}\n`)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- Make extension install and upgrade workflow discoverable for humans using the skill without navigating hidden `.agents` folders.
- Keep extension packaging versioned consistently across Node package and extension manifest.
- Improve release workflow so version bumps can be pushed with tags automatically.

## Why
- Human setup for Chrome extension was failing due to hidden install path visibility.
- Agents needed capability/version metadata to reason about available functions and extension compatibility.
- Manual version alignment between package and manifest was error-prone.

## What changed
- Added automatic visible extension sync helper and install/update hints to `read-active-tab`.
- Added helper to keep `extension/manifest.json` version in sync with root `package.json`.
- Enforced extension version metadata propagation via relay heartbeat/status and source payload.
- Added extension capability metadata in tool output for better agent awareness.
- Added version-release automation hooks to push commit + tags.
- Added symlinked `extension/package.json` to keep package metadata aligned.

## Files changed
- `scripts/extension-install-helper.js`
- `scripts/sync-extension-version.js`
- `scripts/read-active-tab.js`
- `extension/background.js`
- `relay-server.js`
- `extension/manifest.json`
- `package.json`
- `package-lock.json`
- `README.md`
- `SKILL.md`
- `extension/package.json`

## QA / Testing
- `pnpm lint` — passes
- `pnpm knip` — skipped by design: outputs `knip: not configured for this repository; skipped`
- `pnpm build` — passes

## Risks and impacts
- The skill now auto-syncs a visible extension folder under `~/agent-browser-relay/extension`; users with custom layouts should verify Chrome loads that folder.
- Symlinking `extension/package.json` changes extension package metadata assumptions for tooling that expects a real manifest-style package file.
- Added `postversion` push hook will push tags on every `pnpm version` run.

## Rollback plan
- Revert the release/version-hook and sync-script changes (`package.json`, `scripts/sync-extension-version.js`) if automatic tag push is undesirable.
- Restore previous helper behavior by removing `extension-install-helper` integration from `scripts/read-active-tab.js`.
- Reset `extension/package.json` and manifest version fields to prior values if needed.

## Related issues
- None inferred from branch name.

## Checklist
- [x] Tests pass (lint/build)
- [ ] No obvious regressions
- [ ] Documentation updated where needed
- [ ] Rollback path documented
