### PR TITLE
fix(agent-browser-relay): harden extension install onboarding

### DIFF
--- a/scripts/extension-install-helper.js
+++ b/scripts/extension-install-helper.js
@@ -52,6 +52,17 @@ function writeInstallState(state) {
   }
 }
 
+function refreshVisiblePackageManifest() {
+  try {
+    const packageContent = fs.readFileSync(SOURCE_PACKAGE_PATH, 'utf8')
+    fs.rmSync(path.join(VISIBLE_EXTENSION_PATH, 'package.json'), { force: true })
+    fs.writeFileSync(path.join(VISIBLE_EXTENSION_PATH, 'package.json'), packageContent, 'utf8')
+    return
+  } catch {
+    // fallback: if source package cannot be read, keep destination as-is
+  }
+}
+
 function refreshInstallBundle(log = () => {}) {
   const sourceVersion = readManifestVersion(SOURCE_EXTENSION_PATH)
   const relayVersion = readPackageVersion()
@@ -60,6 +71,7 @@ function refreshInstallBundle(log = () => {}) {
 
   let installedVersion = readManifestVersion(VISIBLE_EXTENSION_PATH)
   let updated = false
+  let copyFailed = false
 
   if (!sourceVersion) {
     return {
@@ -70,8 +82,9 @@ function refreshInstallBundle(log = () => {}) {
       relayVersion,
       updated,
       firstRun: false,
-      versionMismatch: false,
+      versionMismatch: copyFailed,
       sourceMissing: true,
+      copyFailed,
     }
   }
 
@@ -81,10 +94,13 @@ function refreshInstallBundle(log = () => {}) {
       fs.rmSync(VISIBLE_EXTENSION_PATH, { recursive: true, force: true })
       fs.cpSync(SOURCE_EXTENSION_PATH, VISIBLE_EXTENSION_PATH, {
         recursive: true,
+        dereference: true,
       })
+      refreshVisiblePackageManifest()
       installedVersion = sourceVersion
       updated = true
     } catch {
+      copyFailed = true
       return {
         ok: false,
         path: VISIBLE_EXTENSION_PATH,
@@ -93,9 +109,9 @@ function refreshInstallBundle(log = () => {}) {
         relayVersion,
         updated,
         firstRun: false,
-        versionMismatch: false,
+        versionMismatch: copyFailed,
         sourceMissing: false,
-        copyFailed: true,
+        copyFailed,
       }
     }
   }
@@ -103,13 +119,24 @@ function refreshInstallBundle(log = () => {}) {
   const installedMissing = Boolean(sourceVersion && !installedVersion)
   const installedMismatch = Boolean(sourceVersion && installedVersion && sourceVersion !== installedVersion)
   const relayMismatch = Boolean(relayVersion && installedVersion && relayVersion !== installedVersion)
-  const mismatch = Boolean(installedMissing || installedMismatch || relayMismatch)
+  const mismatch = Boolean(installedMissing || installedMismatch || relayMismatch || copyFailed)
 
   const firstRun = state.firstRunSeen !== true
   const lastHintAt = Number.isFinite(Number(state.lastHintAt)) ? Number(state.lastHintAt) : 0
   const shouldPrintHint = mismatch || firstRun || (now - lastHintAt >= PROMPT_COOLDOWN_MS)
 
   if (shouldPrintHint) {
+    if (firstRun) {
+      log('[agent-browser-relay] First run setup for this machine:')
+      log('1) Open Chrome and visit chrome://extensions')
+      log('2) Enable Developer mode (top-right)')
+      log('3) Click "Load unpacked"')
+      log(`4) Select this folder:`)
+      log(`   ${VISIBLE_EXTENSION_PATH}`)
+      log('5) Pin Agent Browser Relay in the toolbar (optional but recommended)')
+      log('')
+    }
+
     log(`Chrome extension install path:`)
     log(`  ${VISIBLE_EXTENSION_PATH}`)
     log('Load this folder in chrome://extensions (Load unpacked).')
@@ -145,6 +172,7 @@ function refreshInstallBundle(log = () => {}) {
     firstRun,
     versionMismatch: mismatch,
     sourceMissing: false,
+    copyFailed,
   }
 }
 

--- a/scripts/read-active-tab.js
+++ b/scripts/read-active-tab.js
@@ -4,6 +4,7 @@
 const http = require('node:http')
 const fs = require('node:fs')
 const path = require('node:path')
+const os = require('node:os')
 const { refreshInstallBundle } = require('./extension-install-helper')
 
 const PROJECT_RELEASES_URL = 'https://github.com/Mindgames/agent-browser-relay/releases/latest'
@@ -1766,7 +1767,15 @@ async function main() {
       }
       console.error(`[agent-browser-relay] Download updated bundle from: ${PROJECT_RELEASES_URL}`)
     })
-    .catch(() => {})
+    .catch((error) => {
+      if (installBundle.copyFailed) {
+        console.error('[agent-browser-relay] Failed to sync the visible extension folder for Chrome install.')
+        console.error(`[agent-browser-relay] Verify write permissions for ${path.join(os.homedir(), 'agent-browser-relay')}.`)
+      }
+      if (error && !error.message.includes('ECONNREFUSED')) {
+        console.error(`[agent-browser-relay] Relay status check failed: ${error.message}`)
+      }
+    })
 
   rejectAllPending = (error) => {
     for (const [id, entry] of pending.entries()) {


### PR DESCRIPTION
## Summary
- Hardened first-run Chrome extension installation UX for users installing via `skills.sh` so setup works from a visible folder without needing hidden paths.
- Fixed copied extension bundle consistency by ensuring `~/agent-browser-relay/extension/package.json` is a real file in the visible install folder.
- Improved mismatch/error visibility when extension sync fails.

## Why
- New users were still hit-or-miss on first-time setup because the visible folder could contain a dangling symlink and lacked clear, explicit Chrome setup steps.
- We also needed stronger signaling when extension sync fails so humans are directed to corrective action rather than silently carrying stale/corrupt state.

## What changed
- `scripts/extension-install-helper.js`
  - Added first-run onboarding hints with explicit Chrome steps:
    - open `chrome://extensions`
    - enable Developer mode
    - click Load unpacked
    - select the visible folder
    - optionally pin extension
  - Added resilient visible folder sync behavior:
    - copies extension assets with symlink dereference
    - writes a concrete `~/agent-browser-relay/extension/package.json` from source `package.json`
    - treats copy failure as version mismatch to force user-facing remediation guidance
- `scripts/read-active-tab.js`
  - Added explicit error messaging when visible folder sync fails (permissions/installation path guidance).
  - Added non-fatal relay status error logging when available, while preserving existing behavior.

## Files changed
- `scripts/extension-install-helper.js`
- `scripts/read-active-tab.js`

## QA / Testing
- `node - <<'NODE'\nconst { refreshInstallBundle } = require('./scripts/extension-install-helper')\nconst out = refreshInstallBundle(() => {})\nconsole.log('refresh:', JSON.stringify(out, null, 2))\nNODE`
  - Result: refresh reports `ok: true`, matching versions (`0.0.6` in this environment), and no copy failure.
- `node - <<'NODE'\nconst fs = require('node:fs')\nconst p = process.env.HOME + '/agent-browser-relay/extension/package.json'\nconsole.log('packageExists', fs.existsSync(p), 'isSymlink', fs.lstatSync(p).isSymbolicLink())\nconsole.log('version', JSON.parse(fs.readFileSync(p, 'utf8')).version)\nNODE`
  - Result: `packageExists true isSymlink false`, version present and readable.
- `git diff --stat origin/main..HEAD`
  - Result: only the two target files changed (42 insertions, 5 deletions).

## Risks and impacts
- The visible folder now gets a physical `package.json` file generated from root package metadata during copy. This improves portability but adds a write step during sync.
- Sync failure messaging is now more explicit; behavior remains best-effort and relies on filesystem write access in the user home directory.

## Rollback plan
- Revert this PR if needed.
- Or revert `scripts/extension-install-helper.js` and `scripts/read-active-tab.js` changes to return to prior behavior.

## Related issues
- None confirmed.

## Checklist
- [x] Tests pass
- [ ] No obvious regressions
- [ ] Documentation updated where needed
- [ ] Rollback path documented
