### PR TITLE
docs(relay): require gateway-only tab-scoped runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,11 @@ This refreshes sparse state and restores all missing tracked directories in the 
      - Open/focus the target tab in Chrome.
      - Open the toolbar popup and click **Attach this tab** so the badge shows `ON`.
    - The agent must wait for human confirmation before continuing.
+   - Resolve the target `tabId` from relay status (`/status` or `npm run relay:status -- --all --status-timeout-ms 3000`).
    - Before any read, the agent must run:
 
    ```bash
-   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms 120000
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms 120000
    ```
 
    Continue only when this check succeeds.
@@ -123,7 +124,7 @@ This refreshes sparse state and restores all missing tracked directories in the 
 - Agent must not use direct browser automation/control tools (for example Playwright, Puppeteer, Selenium, `agent-browser`, or ad-hoc Chrome control scripts) for this workflow.
 - Agent must never take control of a random Chrome browser/profile/window; it may operate only on the explicitly attached and leased target tab.
 - After relay startup (`relay:global:start` / `relay:global:install` or `relay:start`), agent must stop and ask the human to attach the target tab, then wait for confirmation.
-- Agent must run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms 120000` before any data read and continue only on success.
+- Agent must run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms 120000` before any data read and continue only on success.
 - For all agent runs (single-agent and concurrent), agent must use tab leasing by setting `--tab-id <tabId>` on all read/check commands.
 - Agent must resolve `tabId` from relay status (`/status` or `npm run relay:status -- --all`) and explicitly target that tab.
 - If the requested `tabId` is not present in status `attachedTabs`, agent must stop and ask the human to re-attach that tab before continuing.

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,10 +59,11 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 4. Check readiness and attach state
 
    ```bash
-   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms "120000"
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "120000"
    ```
 
-   For multi-agent runs, include the assigned tab id:
+   Resolve `<TAB_ID>` from status first (`npm run relay:status -- --all --status-timeout-ms 3000`).
+   For all agent runs, use the assigned tab id:
 
    ```bash
    node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "120000"
@@ -92,7 +93,7 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
   - `curl --max-time 3 -sS "http://127.0.0.1:18793/status"`
   - `npm run relay:status -- --all --status-timeout-ms 3000`
 - After `relay:start`, pause and ask the human to attach the target tab before any read.
-- Run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --check --wait-for-attach --attach-timeout-ms "120000"` before reads and proceed only when it succeeds.
+- Run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms "120000"` before reads and proceed only when it succeeds.
 - For all agent runs (single-agent and concurrent), always pass `--tab-id <tabId>` on check/read commands so every operation is lease-scoped.
 - Do not stop/restart relay during the task unless the human requests it or recovery is explicitly required.
 - Do not restart relay only because code was updated locally; updates are applied on next explicit human-approved restart.
@@ -102,7 +103,7 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 5. Read structured tab payload
 
    ```bash
-   node scripts/read-active-tab.js
+   node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>"
    ```
 
 6. Optional one-command smoke test


### PR DESCRIPTION
## Summary
- Tightened agent usage instructions to enforce gateway-only Chrome interaction through the relay.
- Required tab-scoped execution (`--tab-id`) for all autonomous runs to reduce random tab/profile takeover risk.
- Added explicit stop conditions when the requested tab is not attached in relay status.

## Why this change
- Current behavior reports showed agents sometimes acting on unintended Chrome contexts.
- Immediate mitigation is to harden operational instructions so agents never run unscoped browser control flows.

## What changed
- `SKILL.md`
  - Added gateway-only requirement (`/status` + `node scripts/read-active-tab.js`).
  - Explicitly prohibited direct browser automation tools for this workflow.
  - Required `--tab-id` for all agent runs (single and concurrent).
  - Added guard to stop when requested `tabId` is absent from `attachedTabs`.
  - Clarified that unscoped command examples are manual/debug-only.
- `AGENTS.md`
  - Added matching gateway-only and no-direct-control contract language.
  - Enforced `--tab-id` for all agent reads/checks.
  - Added explicit re-attach gate when `tabId` is missing from attached tabs.
  - Added safety note in workflow section that autonomous runs must be tab-scoped.

## Files changed
- `AGENTS.md`
- `SKILL.md`

## QA / Testing
- Command: `pnpm lint` — Result: pass.
- Command: `pnpm knip` — Result: pass (repository reports `knip: not configured for this repository; skipped`).
- Command: `pnpm build` — Result: pass.

## Risks and impacts
- Low runtime risk: docs-only change.
- Behavioral impact: stricter instructions may require users/agents to supply `--tab-id` consistently.

## Rollback plan
- Revert commit `af69211` on `main` if this policy change causes unwanted workflow friction.

## Related issues
- Fixes #10

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
