### PR TITLE
docs(agents): document global skills install command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,21 @@ Default host/port is `127.0.0.1:18793` (set in code). Override per command with 
 1. Install and open extension
    - After checking out the repository, run `npm run codex:install` to map this copy into:
      `~/.agents/skills/private/agent-browser-relay` (compat path)
-   - If you installed via `npx skills add`, your skill path may instead be:
+   - Recommended global install from GitHub:
+     ```bash
+     npx -y skills add https://github.com/mindgames/agent-browser-relay --skill agent-browser-relay --global --yes
+     ```
+     Optional Codex-only global install:
+     ```bash
+     npx -y skills add https://github.com/mindgames/agent-browser-relay --skill agent-browser-relay --global --agent codex --yes
+     ```
+   - If you installed via `npx skills add`, your skill path is typically:
      `~/.agents/skills/agent-browser-relay`
    - Chrome → `chrome://extensions`
    - Enable Developer mode
-   - Load unpacked and select `~/agent-browser-relay/extension` (preferred visible extension bundle)
+   - Load unpacked and select one of:
+     - `~/.agents/skills/agent-browser-relay/extension` (global `skills add` install)
+     - `~/.agents/skills/private/agent-browser-relay/extension` (`npm run codex:install` compat path)
    - Pin Agent Browser Relay icon to the toolbar
    - Run `npm install` once if this checkout has never installed dependencies.
 2. Start relay server in global mode (preferred, always-on):


### PR DESCRIPTION
## Summary
- Document the explicit global install command for `agent-browser-relay` in `AGENTS.md`.
- Add a Codex-only global install variant.
- Clarify which extension path to load in Chrome for global vs compat installs.

## Why this change
- Installation instructions previously referenced `npx skills add` but did not provide a concrete global command or clear extension path mapping.
- This caused ambiguity and inconsistent installation behavior.

## What changed
- Setup docs in `AGENTS.md` now include:
- `npx -y skills add https://github.com/mindgames/agent-browser-relay --skill agent-browser-relay --global --yes`
- Optional Codex-only variant with `--agent codex`
- Explicit unpacked extension paths for both:
- global `skills add` install (`~/.agents/skills/agent-browser-relay/extension`)
- compat `npm run codex:install` path (`~/.agents/skills/private/agent-browser-relay/extension`)

## Files changed
- `AGENTS.md`

## QA / Testing
- Command: `pnpm lint` — Result: pass
- Command: `pnpm knip` — Result: pass (`not configured; skipped`)
- Command: `pnpm build` — Result: pass

## Risks and impacts
- Low risk: documentation-only update.
- No runtime behavior changes.

## Rollback plan
- Revert commit `1483271`.

## Related issues
- Fixes #16

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
