### PR TITLE
fix(install): create visible extension on install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,18 @@ Default host/port is `127.0.0.1:18793` (set in code). Override per command with 
      ```
    - If you installed via `npx skills add`, your skill path is typically:
      `~/.agents/skills/agent-browser-relay`
+   - Install now also creates a visible Chrome extension folder at:
+     `~/agent-browser-relay/extension`
    - Chrome → `chrome://extensions`
    - Enable Developer mode
    - Load unpacked and select one of:
+     - `~/agent-browser-relay/extension` (preferred visible path created during install)
      - `~/.agents/skills/agent-browser-relay/extension` (global `skills add` install)
      - `~/.agents/skills/private/agent-browser-relay/extension` (`npm run codex:install` compat path)
    - Pin Agent Browser Relay icon to the toolbar
    - Run `npm install` once if this checkout has never installed dependencies.
+   - If `~/agent-browser-relay/extension` is missing after install, run:
+     `npm run extension:install`
 2. Start relay server in global mode (preferred, always-on):
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For unattended global install (recommended in automations/scripts):
 npx skills add Mindgames/Agent-browser-relay -g -y
 ```
 
-On a fresh machine, the first `npm run relay:start` or `npm run relay:global:install` also syncs a visible Chrome extension folder to `~/agent-browser-relay/extension` and prints that path. Load that folder in Chrome before debugging attach/read failures.
+On a fresh machine, install now creates a visible Chrome extension folder at `~/agent-browser-relay/extension` during `npm install` / `skills add`. Runtime commands such as `npm run relay:start` and `npm run relay:global:install` still refresh that folder and print the path as a backup.
 
 ### 2) Load the extension in Chrome (Developer mode)
 After install with the `skills` installer, the skill is available at:
@@ -45,6 +45,7 @@ After install with the `skills` installer, the skill is available at:
    `~/agent-browser-relay/extension`
 
 `relay:start`, `relay:global:install`, and `read-active-tab.js` keep this folder synced and print the install path + version sync status as stderr hints, so humans do not need to find hidden folders.
+If the folder is missing after install, run `npm run extension:install` from the installed skill directory and then load it in Chrome.
 5. Pin the **Agent Browser Relay** toolbar icon
 
 ### 3) Attach tabs and allow broader tab control
@@ -236,6 +237,10 @@ npm run relay:status -- --status-timeout-ms 3000
 - Relay start timed out:
   - Read the startup error and relay log printed by `npm run relay:start`.
   - Do not assume sandbox/network restrictions unless the output shows an actual permission error.
+
+- Visible extension folder missing after install:
+  - Run `npm run extension:install` from the installed skill directory.
+  - Confirm `~/agent-browser-relay/extension` now exists, then load that folder in `chrome://extensions`.
 
 - Attachment lost after navigation/reload:
   - Re-open popup on that tab.

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,8 +10,9 @@ Use this skill to attach to a chosen Chrome tab through the bundled Agent Browse
 ## Quick start
 
 Fresh-machine rule:
-- `npm run relay:start` and `npm run relay:global:install` now sync the visible Chrome extension bundle to `~/agent-browser-relay/extension` and print the exact folder to load.
-- On a new machine, the human must load that folder in `chrome://extensions` before attach/read steps. Do not treat a missing extension install as a sandbox or socket-permission issue.
+- install now creates the visible Chrome extension bundle at `~/agent-browser-relay/extension` during `npm install` / `skills add`
+- `npm run relay:start` and `npm run relay:global:install` still refresh that folder and print the exact folder to load
+- on a new machine, the human must load that folder in `chrome://extensions` before attach/read steps. Do not treat a missing extension install as a sandbox or socket-permission issue.
 
 Defaults are set in code:
 - Host: `127.0.0.1`
@@ -21,7 +22,7 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 
 1. Install dependencies and start relay
 
-   This also prepares the visible Chrome extension folder on first run and prints the path to load in Chrome.
+   This refreshes the visible Chrome extension folder and prints the path to load in Chrome. The folder should already be created during install.
 
    ```bash
    npm run relay:start -- --status-timeout-ms 3000
@@ -44,8 +45,9 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 
    - `chrome://extensions`
    - Enable developer mode
-   - Load unpacked from `~/agent-browser-relay/extension` (this is the visible folder created or refreshed by `relay:start` / `relay:global:install`)
+   - Load unpacked from `~/agent-browser-relay/extension` (this is the visible folder created during install and refreshed by `relay:start` / `relay:global:install`)
    - If the command printed the extension path, treat that printed path as the source of truth
+   - If the folder is missing, run `npm run extension:install` from the installed skill directory
 
 3. Attach the extension to the target tab (open toolbar popup and click attach)
 
@@ -90,7 +92,7 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 - Gateway-only rule: always communicate through the local relay gateway (`/status` and `node scripts/read-active-tab.js`).
 - Never use direct browser-control tooling for this workflow (for example Playwright, Puppeteer, Selenium, `agent-browser`, or ad-hoc Chrome control scripts).
 - Never take control of a random Chrome window/profile. Only operate on the explicitly attached target tab leased via `--tab-id`.
-- On a fresh machine, after `relay:start` or `relay:global:install`, explicitly tell the human to load `~/agent-browser-relay/extension` in `chrome://extensions` before any attach/read attempt.
+- On a fresh machine, explicitly tell the human to load `~/agent-browser-relay/extension` in `chrome://extensions` before any attach/read attempt.
 - Canonical commands:
   - `npm run relay:start`
   - `npm run relay:status`

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "grais-debugger-relay",
-  "version": "0.1.0",
+  "name": "agent-browser-relay",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "agent-browser-relay",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-browser-relay",
-      "version": "0.0.7",
+      "version": "0.0.8",
+      "hasInstallScript": true,
       "dependencies": {
         "ws": "^8.18.2"
       },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "sync:extension-version": "node scripts/sync-extension-version.js",
+    "extension:install": "node scripts/extension-install-helper.js",
     "lint": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",
     "knip": "node -e \"console.log('knip: not configured for this repository; skipped')\"",
     "build": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",
@@ -31,6 +32,7 @@
     "relay:global:status": "node scripts/relay-service.js status",
     "codex:install": "bash scripts/codex-skill-link.sh",
     "codex:install:check": "bash scripts/codex-skill-link.sh --check",
+    "postinstall": "node scripts/extension-install-helper.js",
     "preversion": "node scripts/sync-extension-version.js",
     "version": "node scripts/sync-extension-version.js && git add extension/manifest.json",
     "postversion": "git push && git push --tags",

--- a/scripts/extension-install-helper.js
+++ b/scripts/extension-install-helper.js
@@ -127,7 +127,7 @@ function refreshInstallBundle(log = () => {}) {
 
   if (shouldPrintHint) {
     if (firstRun) {
-      log('[agent-browser-relay] First run setup for this machine:')
+      log('First run setup for this machine:')
       log('1) Open Chrome and visit chrome://extensions')
       log('2) Enable Developer mode (top-right)')
       log('3) Click "Load unpacked"')


### PR DESCRIPTION
## Summary
- create `~/agent-browser-relay/extension` during package install instead of waiting for a later runtime command
- add an explicit `npm run extension:install` fallback for installs where the visible folder is missing
- update setup docs so fresh-machine guidance matches the new install-time behavior

## Why this change
- a fresh-machine install can finish without creating `~/agent-browser-relay/extension`, which breaks the Chrome "Load unpacked" step even before relay startup
- relying only on `relay:start` / `relay:global:install` to create the visible folder is weaker than creating it at install time
- the docs currently imply a smoother install path than the package actually delivers

## What changed
- added `postinstall` to run `scripts/extension-install-helper.js` during `npm install`
- added `npm run extension:install` as a manual repair command
- updated README, SKILL, and AGENTS instructions to say the visible folder should be created during install and to document the fallback command
- kept the existing runtime refresh behavior intact

## Files changed
- `package.json`
- `package-lock.json`
- `node_modules/.package-lock.json`
- `scripts/extension-install-helper.js`
- `README.md`
- `SKILL.md`
- `AGENTS.md`

## QA / Testing
- Command: `npm run lint` — Result: passed
- Command: `npm run build` — Result: passed
- Command: `HOME=$(mktemp -d) npm install --no-audit --no-fund` — Result: ran `postinstall` and created `<temp-home>/agent-browser-relay/extension`
- Command: `HOME=$(mktemp -d) npm run extension:install` — Result: created the visible extension folder and printed the load path

## Risks and impacts
- `npm install` now has a visible side effect in the user home directory by design
- installs where the home directory is unwritable will now surface that failure during package install instead of deferring it until relay startup
- package lockfiles changed to record the install hook and current package metadata

## Rollback plan
- revert commit `4d471b4` to remove the install-time hook and restore the previous runtime-only folder creation path

## Related issues
- none

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
