### PR TITLE
fix(relay): decouple startup from visible copy failures

### DIFF
--- a/scripts/codex-skill-link.sh
+++ b/scripts/codex-skill-link.sh
@@ -11,6 +11,8 @@ VISIBLE_EXTENSION_PATH="${VISIBLE_ROOT}/extension"
 
 MODE="install"
 FORCE=0
+EXTENSION_INSTALL_STATUS=0
+EXTENSION_INSTALL_OUTPUT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -131,7 +133,17 @@ fi
 ln -sfn "$CANONICAL_SKILL_PATH" "$LEGACY_ALIAS_PATH"
 
 if command -v node >/dev/null 2>&1; then
-  node "$REPO_ROOT/scripts/extension-install-helper.js" >/dev/null 2>&1 || true
+  set +e
+  EXTENSION_INSTALL_OUTPUT="$(node "$REPO_ROOT/scripts/extension-install-helper.js" 2>&1)"
+  EXTENSION_INSTALL_STATUS=$?
+  set -e
+else
+  EXTENSION_INSTALL_STATUS=127
+  EXTENSION_INSTALL_OUTPUT="[codex-skill] WARNING: node is not available; skipping visible extension preparation."
+fi
+
+if [[ -n "$EXTENSION_INSTALL_OUTPUT" ]]; then
+  printf '%s\n' "$EXTENSION_INSTALL_OUTPUT"
 fi
 
 echo "[codex-skill] Linked skill workspace:"
@@ -140,6 +152,14 @@ echo "[codex-skill] Linked compatibility alias:"
 echo "[codex-skill]   $LEGACY_ALIAS_PATH -> $CANONICAL_SKILL_PATH"
 echo "[codex-skill] Chrome load target:"
 echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"
-echo "[codex-skill] Visible Chrome extension folder:"
-echo "[codex-skill]   $VISIBLE_EXTENSION_PATH"
-echo "[codex-skill] Load this folder in chrome://extensions -> Load unpacked"
+if [[ "$EXTENSION_INSTALL_STATUS" -eq 0 ]]; then
+  echo "[codex-skill] Visible Chrome extension folder:"
+  echo "[codex-skill]   $VISIBLE_EXTENSION_PATH"
+  echo "[codex-skill] Load this folder in chrome://extensions -> Load unpacked"
+else
+  echo "[codex-skill] WARNING: visible Chrome extension folder was not prepared."
+  echo "[codex-skill] Load the canonical extension path for now:"
+  echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"
+  echo "[codex-skill] Then repair the visible folder with:"
+  echo "[codex-skill]   npm run extension:install"
+fi

--- a/scripts/relay-manager.js
+++ b/scripts/relay-manager.js
@@ -131,12 +131,22 @@ function prepareVisibleExtensionBundle() {
       console.error(`[agent-browser-relay] ${message}`)
     })
   } catch (error) {
-    throw new Error(
-      `[agent-browser-relay] Failed to prepare visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
+    console.warn(
+      [
+        `[agent-browser-relay] Failed to prepare visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
+        'Relay startup will continue, but the visible Chrome extension folder may be stale or missing.',
+      ].join(' '),
     )
+    return null
   }
   if (!result || result.ok !== true) {
-    throw new Error(describeInstallBundleFailure(result))
+    console.warn(
+      [
+        describeInstallBundleFailure(result),
+        'Relay startup will continue, but the visible Chrome extension folder may be stale or missing.',
+      ].join(' '),
+    )
+    return result
   }
   return result
 }

--- a/scripts/relay-service.js
+++ b/scripts/relay-service.js
@@ -110,12 +110,22 @@ function prepareVisibleExtensionBundle() {
       console.error(`[agent-browser-relay] ${message}`)
     })
   } catch (error) {
-    throw new Error(
-      `[agent-browser-relay] Failed to prepare visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
+    console.warn(
+      [
+        `[agent-browser-relay] Failed to prepare visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
+        'Relay service operations will continue, but the visible Chrome extension folder may be stale or missing.',
+      ].join(' '),
     )
+    return null
   }
   if (!result || result.ok !== true) {
-    throw new Error(describeInstallBundleFailure(result))
+    console.warn(
+      [
+        describeInstallBundleFailure(result),
+        'Relay service operations will continue, but the visible Chrome extension folder may be stale or missing.',
+      ].join(' '),
+    )
+    return result
   }
   return result
 }


### PR DESCRIPTION
## Summary
- make relay manager startup continue when refreshing the visible Chrome extension copy fails
- make relay service lifecycle commands continue under the same visible-copy failure condition
- make `codex:install` surface visible-copy failures honestly instead of pretending the folder is ready

## Why this change
- the previous fix over-corrected by making `relay:start` and relay service commands hard-depend on the advisory `~/agent-browser-relay/extension` copy
- that broke the dependency boundary: relay/service operations can still be valid even when the human-facing visible copy cannot be refreshed
- `codex:install` had the opposite problem and hid extension-copy failure entirely while still pointing the user at a missing folder

## What changed
- `scripts/relay-manager.js`
  - bundle refresh failures now emit warnings and startup continues into the normal status/start path
- `scripts/relay-service.js`
  - bundle refresh failures now emit warnings and service commands continue into their real service logic
- `scripts/codex-skill-link.sh`
  - helper output is now surfaced instead of discarded
  - success output only advertises the visible folder when it was actually prepared
  - failure output now tells the user to use the canonical extension path temporarily and repair the visible folder with `npm run extension:install`

## Files changed
- `scripts/relay-manager.js`
- `scripts/relay-service.js`
- `scripts/codex-skill-link.sh`

## QA / Testing
- Command: `npm run lint` — Result: passed
- Command: `npm run build` — Result: passed
- Command: `npm run relay:stop` — Result: stopped existing local relay before smoke test
- Command: `HOME=<temp-home-with-agent-browser-relay-file> npm run relay:start -- --status-timeout-ms 3000 --start-timeout-ms 3000` — Result: warned about visible-copy failure and still started relay successfully
- Command: `HOME=<temp-home-with-agent-browser-relay-file> node scripts/relay-service.js start` — Result: warned about visible-copy failure and continued to the expected `Service not installed` message instead of aborting on bundle refresh
- Command: `HOME=<temp-home-with-agent-browser-relay-file> bash scripts/codex-skill-link.sh` — Result: surfaced the visible-copy failure and printed the canonical extension path fallback plus `npm run extension:install`
- Command: `npm run relay:stop` — Result: stopped smoke-test relay cleanly

## Risks and impacts
- relay and service commands now treat visible-copy refresh as advisory again, so users must still notice warnings if the visible folder was not refreshed
- `codex:install` output is noisier because it now prints helper diagnostics instead of suppressing them
- this keeps the install-time visible-folder creation from PR #20 intact while changing only failure handling

## Rollback plan
- revert commit `3a4c97c` to restore the prior hard-fail startup behavior and silent `codex:install` helper handling

## Related issues
- Fixes #21

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
