### PR TITLE
fix(relay): use installed skill path as primary extension path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,23 +33,23 @@ Default host/port is `127.0.0.1:18793` (set in code). Override per command with 
      ```bash
      npx -y skills add https://github.com/mindgames/agent-browser-relay --skill agent-browser-relay --global --yes
      ```
-     Optional Codex-only global install:
+   - Optional Codex-only global install:
      ```bash
      npx -y skills add https://github.com/mindgames/agent-browser-relay --skill agent-browser-relay --global --agent codex --yes
      ```
    - If you installed via `npx skills add`, your skill path is typically:
      `~/.agents/skills/agent-browser-relay`
-   - Install now also creates a visible Chrome extension folder at:
-     `~/agent-browser-relay/extension`
+   - The guaranteed Chrome load path after `skills add` is:
+     `~/.agents/skills/agent-browser-relay/extension`
    - Chrome → `chrome://extensions`
    - Enable Developer mode
-   - Load unpacked and select one of:
-     - `~/agent-browser-relay/extension` (preferred visible path created during install)
+   - Load unpacked and select the path that matches how this copy was installed:
      - `~/.agents/skills/agent-browser-relay/extension` (global `skills add` install)
      - `~/.agents/skills/private/agent-browser-relay/extension` (`npm run codex:install` compat path)
+   - `npm run extension:path` prints the exact current primary load path again
    - Pin Agent Browser Relay icon to the toolbar
    - Run `npm install` once if this checkout has never installed dependencies.
-   - If `~/agent-browser-relay/extension` is missing after install, run:
+   - `~/agent-browser-relay/extension` is only an optional visible convenience copy. If you want it, run:
      `npm run extension:install`
 2. Start relay server in global mode (preferred, always-on):
 
@@ -135,6 +135,7 @@ This refreshes sparse state and restores all missing tracked directories in the 
 
 ## Agent execution contract (mandatory)
 - Use these exact scripts and command names. Do not search for alternatives and do not say they "may be named differently":
+  - `npm run extension:path`
   - `npm run relay:global:install`
   - `npm run relay:global:status`
   - `npm run relay:global:start`
@@ -146,6 +147,7 @@ This refreshes sparse state and restores all missing tracked directories in the 
 - Gateway-only rule: agent must communicate with Chrome only via this relay gateway (`/status` + `node scripts/read-active-tab.js`).
 - Agent must not use direct browser automation/control tools (for example Playwright, Puppeteer, Selenium, `agent-browser`, or ad-hoc Chrome control scripts) for this workflow.
 - Agent must never take control of a random Chrome browser/profile/window; it may operate only on the explicitly attached and leased target tab.
+- On a fresh machine, agent must tell the human to load the primary extension path from `npm run extension:path` before attach/read steps. After `skills add`, that is normally `~/.agents/skills/agent-browser-relay/extension`.
 - After relay startup (`relay:global:start` / `relay:global:install` or `relay:start`), agent must stop and ask the human to attach the target tab, then wait for confirmation.
 - Agent must run `node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --check --wait-for-attach --attach-timeout-ms 120000` before any data read and continue only on success.
 - For workflows that create tabs with `Target.createTarget`, agent must additionally require target-create readiness via `--require-target-create`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For unattended global install (recommended in automations/scripts):
 npx skills add Mindgames/Agent-browser-relay -g -y
 ```
 
-On a fresh machine, install now creates a visible Chrome extension folder at `~/agent-browser-relay/extension` during `npm install` / `skills add`. Runtime commands such as `npm run relay:start` and `npm run relay:global:install` still refresh that folder and print the path as a backup.
+`skills add` guarantees the installed skill at `~/.agents/skills/agent-browser-relay`. It does not guarantee the optional visible convenience copy at `~/agent-browser-relay/extension`.
 
 ### 2) Load the extension in Chrome (Developer mode)
 After install with the `skills` installer, the skill is available at:
@@ -42,10 +42,11 @@ After install with the `skills` installer, the skill is available at:
 2. Enable **Developer mode**
 3. Click **Load unpacked**
 4. Select this folder:
-   `~/agent-browser-relay/extension`
+   `~/.agents/skills/agent-browser-relay/extension`
 
-`relay:start`, `relay:global:install`, and `read-active-tab.js` keep this folder synced and print the install path + version sync status as stderr hints, so humans do not need to find hidden folders.
-If the folder is missing after install, run `npm run extension:install` from the installed skill directory and then load it in Chrome.
+Run `npm run extension:path` from the installed skill directory any time you want the exact current load path printed again.
+`relay:start`, `relay:global:install`, and `read-active-tab.js` also print the primary load path + version sync status as stderr hints.
+If you specifically want the visible convenience copy at `~/agent-browser-relay/extension`, run `npm run extension:install` from the installed skill directory.
 5. Pin the **Agent Browser Relay** toolbar icon
 
 ### 3) Attach tabs and allow broader tab control
@@ -66,7 +67,7 @@ Example prompt to your agent:
 Expected flow:
 
 1. Agent starts relay (for example `npm run relay:global:install -- --ports 18793 --timeout 12000`).
-2. On a new machine, agent tells you to load `~/agent-browser-relay/extension` in `chrome://extensions` first.
+2. On a new machine, agent tells you to load `~/.agents/skills/agent-browser-relay/extension` in `chrome://extensions` first, or asks you to run `npm run extension:path`.
 3. Agent asks you to open/focus the target tab and click **Attach this tab** in the popup.
 4. You attach the tab and confirm.
 5. Agent runs the attach check and continues reads using the tab ID you shared.
@@ -82,7 +83,7 @@ This repo integrates with two different skill roots:
 - `~/.claude/skills/agent-browser-relay`
   - Usually symlinked automatically by the `skills` installer when Claude Code is present.
 - `~/agent-browser-relay/extension`
-  - Visible Chrome extension directory printed by the skill and safe for manual navigation in Chrome.
+  - Optional visible convenience copy created by `npm run extension:install` when writable.
 
 Why this matters: installer-based setup gives a stable path and keeps Codex/Claude integrations consistent.
 
@@ -93,7 +94,7 @@ Why this matters: installer-based setup gives a stable path and keeps Codex/Clau
 - `scripts/relay-service.js`: global `launchd/systemd --user` service lifecycle.
 - `scripts/read-active-tab.js`: read/check CLI that prints JSON.
 - Relay tab leasing (`--tab-id`): isolates concurrent agents to specific tabs.
-- `scripts/extension-install-helper.js`: keeps a visible extension install folder in sync.
+- `scripts/extension-install-helper.js`: prints the primary extension path and optionally refreshes the visible convenience copy.
 
 ## Capability library exposed to callers
 
@@ -238,9 +239,13 @@ npm run relay:status -- --status-timeout-ms 3000
   - Read the startup error and relay log printed by `npm run relay:start`.
   - Do not assume sandbox/network restrictions unless the output shows an actual permission error.
 
-- Visible extension folder missing after install:
+- Unsure which extension folder to load:
+  - Run `npm run extension:path` from the installed skill directory.
+  - Load the primary path it prints in `chrome://extensions`.
+
+- Visible convenience folder missing after install:
   - Run `npm run extension:install` from the installed skill directory.
-  - Confirm `~/agent-browser-relay/extension` now exists, then load that folder in `chrome://extensions`.
+  - Confirm `~/agent-browser-relay/extension` now exists if you want that shortcut.
 
 - Attachment lost after navigation/reload:
   - Re-open popup on that tab.
@@ -268,6 +273,7 @@ Use only these script names:
 - `npm run relay:start`
 - `npm run relay:status`
 - `npm run relay:stop`
+- `npm run extension:path`
 - `node scripts/read-active-tab.js`
 
 Do not restart relay just because local files changed. Restart only when explicitly requested by a human, or for hard recovery failures.

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,9 +10,11 @@ Use this skill to attach to a chosen Chrome tab through the bundled Agent Browse
 ## Quick start
 
 Fresh-machine rule:
-- install now creates the visible Chrome extension bundle at `~/agent-browser-relay/extension` during `npm install` / `skills add`
-- `npm run relay:start` and `npm run relay:global:install` still refresh that folder and print the exact folder to load
-- on a new machine, the human must load that folder in `chrome://extensions` before attach/read steps. Do not treat a missing extension install as a sandbox or socket-permission issue.
+- `skills add` guarantees the installed skill at `~/.agents/skills/agent-browser-relay`
+- the guaranteed Chrome load path after `skills add` is `~/.agents/skills/agent-browser-relay/extension`
+- `~/agent-browser-relay/extension` is only an optional visible convenience copy created by `npm run extension:install`
+- `npm run extension:path`, `npm run relay:start`, and `npm run relay:global:install` print the primary folder to load
+- on a new machine, the human must load the primary path in `chrome://extensions` before attach/read steps. Do not treat a missing visible convenience copy as a sandbox or socket-permission issue.
 
 Defaults are set in code:
 - Host: `127.0.0.1`
@@ -22,7 +24,7 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 
 1. Install dependencies and start relay
 
-   This refreshes the visible Chrome extension folder and prints the path to load in Chrome. The folder should already be created during install.
+   This prints the primary Chrome extension path to load in Chrome and refreshes the optional visible convenience copy when possible.
 
    ```bash
    npm run relay:start -- --status-timeout-ms 3000
@@ -45,9 +47,10 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 
    - `chrome://extensions`
    - Enable developer mode
-   - Load unpacked from `~/agent-browser-relay/extension` (this is the visible folder created during install and refreshed by `relay:start` / `relay:global:install`)
+   - Load unpacked from `~/.agents/skills/agent-browser-relay/extension` after `skills add`
    - If the command printed the extension path, treat that printed path as the source of truth
-   - If the folder is missing, run `npm run extension:install` from the installed skill directory
+   - Run `npm run extension:path` from the installed skill directory any time you want the exact path printed again
+   - `~/agent-browser-relay/extension` is optional; create it with `npm run extension:install` if you want a visible shortcut
 
 3. Attach the extension to the target tab (open toolbar popup and click attach)
 
@@ -92,8 +95,9 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
 - Gateway-only rule: always communicate through the local relay gateway (`/status` and `node scripts/read-active-tab.js`).
 - Never use direct browser-control tooling for this workflow (for example Playwright, Puppeteer, Selenium, `agent-browser`, or ad-hoc Chrome control scripts).
 - Never take control of a random Chrome window/profile. Only operate on the explicitly attached target tab leased via `--tab-id`.
-- On a fresh machine, explicitly tell the human to load `~/agent-browser-relay/extension` in `chrome://extensions` before any attach/read attempt.
+- On a fresh machine, explicitly tell the human to load the primary extension path from `npm run extension:path` before any attach/read attempt. After `skills add`, that is normally `~/.agents/skills/agent-browser-relay/extension`.
 - Canonical commands:
+  - `npm run extension:path`
   - `npm run relay:start`
   - `npm run relay:status`
   - `npm run relay:stop`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "sync:extension-version": "node scripts/sync-extension-version.js",
     "extension:install": "node scripts/extension-install-helper.js",
+    "extension:path": "node scripts/extension-install-helper.js --paths",
     "lint": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",
     "knip": "node -e \"console.log('knip: not configured for this repository; skipped')\"",
     "build": "node --check relay-server.js extension/background.js extension/options.js scripts/read-active-tab.js scripts/relay-manager.js scripts/relay-service.js",
@@ -32,7 +33,6 @@
     "relay:global:status": "node scripts/relay-service.js status",
     "codex:install": "bash scripts/codex-skill-link.sh",
     "codex:install:check": "bash scripts/codex-skill-link.sh --check",
-    "postinstall": "node scripts/extension-install-helper.js",
     "preversion": "node scripts/sync-extension-version.js",
     "version": "node scripts/sync-extension-version.js && git add extension/manifest.json",
     "postversion": "git push && git push --tags",

--- a/scripts/codex-skill-link.sh
+++ b/scripts/codex-skill-link.sh
@@ -105,7 +105,7 @@ if [[ -d "$CANONICAL_SKILL_PATH" && ! -L "$CANONICAL_SKILL_PATH" ]]; then
   existing_root="$(cd "$CANONICAL_SKILL_PATH" && pwd -P)"
   if [[ "$existing_root" == "$REPO_ROOT" ]]; then
     echo "[codex-skill] Reusing existing repository path at $CANONICAL_SKILL_PATH"
-    echo "[codex-skill] Chrome load target:"
+    echo "[codex-skill] Primary Chrome load path:"
     echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"
     NEED_CANONICAL_LINK=0
   else
@@ -150,16 +150,18 @@ echo "[codex-skill] Linked skill workspace:"
 echo "[codex-skill]   $CANONICAL_SKILL_PATH -> $REPO_ROOT"
 echo "[codex-skill] Linked compatibility alias:"
 echo "[codex-skill]   $LEGACY_ALIAS_PATH -> $CANONICAL_SKILL_PATH"
-echo "[codex-skill] Chrome load target:"
+echo "[codex-skill] Primary Chrome load path:"
 echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"
 if [[ "$EXTENSION_INSTALL_STATUS" -eq 0 ]]; then
-  echo "[codex-skill] Visible Chrome extension folder:"
+  echo "[codex-skill] Optional visible convenience path:"
   echo "[codex-skill]   $VISIBLE_EXTENSION_PATH"
-  echo "[codex-skill] Load this folder in chrome://extensions -> Load unpacked"
+  echo "[codex-skill] Chrome can load either path, but the primary path above is the guaranteed install location."
 else
-  echo "[codex-skill] WARNING: visible Chrome extension folder was not prepared."
-  echo "[codex-skill] Load the canonical extension path for now:"
+  echo "[codex-skill] WARNING: optional visible convenience path was not prepared."
+  echo "[codex-skill] Load the primary extension path:"
   echo "[codex-skill]   $CANONICAL_EXTENSION_PATH"
-  echo "[codex-skill] Then repair the visible folder with:"
+  echo "[codex-skill] If you want the visible shortcut later, run:"
   echo "[codex-skill]   npm run extension:install"
 fi
+echo "[codex-skill] To print the exact current load path again:"
+echo "[codex-skill]   npm run extension:path"

--- a/scripts/extension-install-helper.js
+++ b/scripts/extension-install-helper.js
@@ -9,6 +9,11 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const SOURCE_EXTENSION_PATH = path.join(REPO_ROOT, 'extension')
 const SOURCE_PACKAGE_PATH = path.join(REPO_ROOT, 'package.json')
 
+const GLOBAL_SKILL_ROOT = path.join(os.homedir(), '.agents', 'skills', 'agent-browser-relay')
+const GLOBAL_EXTENSION_PATH = path.join(GLOBAL_SKILL_ROOT, 'extension')
+const PRIVATE_SKILL_ROOT = path.join(os.homedir(), '.agents', 'skills', 'private', 'agent-browser-relay')
+const PRIVATE_EXTENSION_PATH = path.join(PRIVATE_SKILL_ROOT, 'extension')
+
 const VISIBLE_ROOT = path.join(os.homedir(), 'agent-browser-relay')
 const VISIBLE_EXTENSION_PATH = path.join(VISIBLE_ROOT, 'extension')
 const VISIBLE_STATE_PATH = path.join(VISIBLE_ROOT, 'extension-install-state.json')
@@ -52,43 +57,62 @@ function writeInstallState(state) {
   }
 }
 
+function safeRealpath(targetPath) {
+  try {
+    return fs.realpathSync(targetPath)
+  } catch {
+    return null
+  }
+}
+
 function refreshVisiblePackageManifest() {
   try {
     const packageContent = fs.readFileSync(SOURCE_PACKAGE_PATH, 'utf8')
     fs.rmSync(path.join(VISIBLE_EXTENSION_PATH, 'package.json'), { force: true })
     fs.writeFileSync(path.join(VISIBLE_EXTENSION_PATH, 'package.json'), packageContent, 'utf8')
-    return
   } catch {
     // fallback: if source package cannot be read, keep destination as-is
   }
 }
 
-function refreshInstallBundle(log = () => {}) {
-  const sourceVersion = readManifestVersion(SOURCE_EXTENSION_PATH)
-  const relayVersion = readPackageVersion()
-  const state = readInstallState()
-  const now = Date.now()
+function resolvePrimaryLoadTarget() {
+  const sourceRealPath = safeRealpath(SOURCE_EXTENSION_PATH)
+  const candidates = [
+    { path: GLOBAL_EXTENSION_PATH, kind: 'global-skill' },
+    { path: PRIVATE_EXTENSION_PATH, kind: 'private-skill' },
+    { path: SOURCE_EXTENSION_PATH, kind: 'checkout' },
+  ]
 
-  let installedVersion = readManifestVersion(VISIBLE_EXTENSION_PATH)
+  for (const candidate of candidates) {
+    const candidateRealPath = safeRealpath(candidate.path)
+    if (sourceRealPath && candidateRealPath && candidateRealPath === sourceRealPath) {
+      return candidate
+    }
+  }
+
+  return { path: SOURCE_EXTENSION_PATH, kind: 'checkout' }
+}
+
+function describePrimaryLoadPathKind(kind) {
+  if (kind === 'global-skill') return 'global skills install'
+  if (kind === 'private-skill') return 'Codex compatibility install'
+  return 'current checkout'
+}
+
+function prepareVisibleExtensionCopy(sourceVersion) {
+  let visibleVersion = readManifestVersion(VISIBLE_EXTENSION_PATH)
   let updated = false
   let copyFailed = false
 
   if (!sourceVersion) {
     return {
-      ok: false,
-      path: VISIBLE_EXTENSION_PATH,
-      installedVersion,
-      sourceVersion,
-      relayVersion,
+      visibleVersion,
       updated,
-      firstRun: false,
-      versionMismatch: copyFailed,
-      sourceMissing: true,
       copyFailed,
     }
   }
 
-  if (!installedVersion || installedVersion !== sourceVersion) {
+  if (!visibleVersion || visibleVersion !== sourceVersion) {
     try {
       fs.mkdirSync(VISIBLE_ROOT, { recursive: true })
       fs.rmSync(VISIBLE_EXTENSION_PATH, { recursive: true, force: true })
@@ -97,110 +121,261 @@ function refreshInstallBundle(log = () => {}) {
         dereference: true,
       })
       refreshVisiblePackageManifest()
-      installedVersion = sourceVersion
+      visibleVersion = sourceVersion
       updated = true
     } catch {
       copyFailed = true
-      return {
-        ok: false,
-        path: VISIBLE_EXTENSION_PATH,
-        installedVersion,
-        sourceVersion,
-        relayVersion,
-        updated,
-        firstRun: false,
-        versionMismatch: copyFailed,
-        sourceMissing: false,
-        copyFailed,
-      }
+      visibleVersion = readManifestVersion(VISIBLE_EXTENSION_PATH)
     }
   }
 
-  const installedMissing = Boolean(sourceVersion && !installedVersion)
-  const installedMismatch = Boolean(sourceVersion && installedVersion && sourceVersion !== installedVersion)
-  const relayMismatch = Boolean(relayVersion && installedVersion && relayVersion !== installedVersion)
-  const mismatch = Boolean(installedMissing || installedMismatch || relayMismatch || copyFailed)
+  return {
+    visibleVersion,
+    updated,
+    copyFailed,
+  }
+}
 
+function refreshInstallBundle(log = () => {}, options = {}) {
+  const prepareVisible = options.prepareVisible !== false
+  const printHint = options.printHint !== false
+
+  const sourceVersion = readManifestVersion(SOURCE_EXTENSION_PATH)
+  const relayVersion = readPackageVersion()
+  const primaryTarget = resolvePrimaryLoadTarget()
+  const primaryVersion =
+    primaryTarget.path === SOURCE_EXTENSION_PATH
+      ? sourceVersion
+      : readManifestVersion(primaryTarget.path)
+
+  let visibleVersion = readManifestVersion(VISIBLE_EXTENSION_PATH)
+  let updated = false
+  let copyFailed = false
+
+  if (!sourceVersion) {
+    return {
+      ok: false,
+      path: primaryTarget.path,
+      pathKind: primaryTarget.kind,
+      sourcePath: SOURCE_EXTENSION_PATH,
+      visiblePath: VISIBLE_EXTENSION_PATH,
+      installedVersion: primaryVersion,
+      visibleVersion,
+      sourceVersion,
+      relayVersion,
+      updated,
+      firstRun: false,
+      versionMismatch: false,
+      sourceMissing: true,
+      copyFailed,
+      visiblePathReady: false,
+      visiblePathNeedsRefresh: false,
+    }
+  }
+
+  if (prepareVisible) {
+    const visibleCopy = prepareVisibleExtensionCopy(sourceVersion)
+    visibleVersion = visibleCopy.visibleVersion
+    updated = visibleCopy.updated
+    copyFailed = visibleCopy.copyFailed
+  }
+
+  const visiblePathReady = Boolean(sourceVersion && visibleVersion && visibleVersion === sourceVersion)
+  const visiblePathNeedsRefresh = Boolean(sourceVersion && (!visibleVersion || visibleVersion !== sourceVersion))
+  const versionMismatch = Boolean(primaryVersion && relayVersion && primaryVersion !== relayVersion)
+
+  const state = readInstallState()
+  const now = Date.now()
   const firstRun = state.firstRunSeen !== true
   const lastHintAt = Number.isFinite(Number(state.lastHintAt)) ? Number(state.lastHintAt) : 0
-  const shouldPrintHint = mismatch || firstRun || (now - lastHintAt >= PROMPT_COOLDOWN_MS)
+  const shouldPrintHint =
+    versionMismatch ||
+    copyFailed ||
+    visiblePathNeedsRefresh ||
+    firstRun ||
+    (now - lastHintAt >= PROMPT_COOLDOWN_MS)
 
-  if (shouldPrintHint) {
+  if (printHint && shouldPrintHint) {
     if (firstRun) {
       log('First run setup for this machine:')
       log('1) Open Chrome and visit chrome://extensions')
       log('2) Enable Developer mode (top-right)')
       log('3) Click "Load unpacked"')
-      log(`4) Select this folder:`)
-      log(`   ${VISIBLE_EXTENSION_PATH}`)
+      log('4) Select this folder:')
+      log(`   ${primaryTarget.path}`)
       log('5) Pin Agent Browser Relay in the toolbar (optional but recommended)')
       log('')
     }
 
-    log(`Chrome extension install path:`)
-    log(`  ${VISIBLE_EXTENSION_PATH}`)
+    log('Primary Chrome extension path:')
+    log(`  ${primaryTarget.path}`)
+    log(`This is the guaranteed extension folder from the ${describePrimaryLoadPathKind(primaryTarget.kind)}.`)
     log('Load this folder in chrome://extensions (Load unpacked).')
-    log('If the extension was previously loaded from another folder, repoint it here.')
-    log(`Extension version: ${installedVersion || 'unknown'}`)
+
+    if (visiblePathReady) {
+      log('Optional visible convenience path:')
+      log(`  ${VISIBLE_EXTENSION_PATH}`)
+    } else {
+      log('Optional visible convenience path is not prepared:')
+      log(`  ${VISIBLE_EXTENSION_PATH}`)
+      log('If you want that shortcut, run `npm run extension:install` from the installed skill directory.')
+    }
+
+    log(`Extension version: ${primaryVersion || 'unknown'}`)
     log(`Relay package version: ${relayVersion || 'unknown'}`)
-    log(`Source manifest version: ${sourceVersion || 'unknown'}`)
-    if (mismatch) {
+    if (visibleVersion) {
+      log(`Visible convenience version: ${visibleVersion}`)
+    }
+    if (versionMismatch) {
       log('Version mismatch detected. Download newest extension bundle from:')
       log(`  ${PROJECT_URL}`)
-      log(`Or update from releases:`)
+      log('Or update from releases:')
       log(`  ${PROJECT_RELEASES_URL}`)
     }
   }
 
-  writeInstallState({
-    lastHintAt: now,
-    firstRunSeen: true,
-    lastCheckedAt: now,
-    installedVersion,
-    relayVersion,
-    sourceVersion,
-    mismatch: mismatch,
-  })
+  if (printHint) {
+    writeInstallState({
+      lastHintAt: now,
+      firstRunSeen: true,
+      lastCheckedAt: now,
+      primaryPath: primaryTarget.path,
+      primaryPathKind: primaryTarget.kind,
+      installedVersion: primaryVersion,
+      visibleVersion,
+      relayVersion,
+      sourceVersion,
+      mismatch: versionMismatch,
+      visiblePathReady,
+      visiblePathNeedsRefresh,
+    })
+  }
 
   return {
-    ok: true,
-    path: VISIBLE_EXTENSION_PATH,
-    installedVersion,
+    ok: prepareVisible ? !copyFailed : true,
+    path: primaryTarget.path,
+    pathKind: primaryTarget.kind,
+    sourcePath: SOURCE_EXTENSION_PATH,
+    visiblePath: VISIBLE_EXTENSION_PATH,
+    installedVersion: primaryVersion,
+    visibleVersion,
     sourceVersion,
     relayVersion,
     updated,
     firstRun,
-    versionMismatch: mismatch,
+    versionMismatch,
     sourceMissing: false,
     copyFailed,
+    visiblePathReady,
+    visiblePathNeedsRefresh,
   }
 }
 
 function describeInstallBundleFailure(result) {
-  const targetPath = result?.path || VISIBLE_EXTENSION_PATH
+  const targetPath = result?.visiblePath || VISIBLE_EXTENSION_PATH
+  const primaryPath = result?.path || SOURCE_EXTENSION_PATH
   if (result?.sourceMissing) {
-    return `[agent-browser-relay] Failed to prepare visible extension folder at ${targetPath}: extension source is missing from ${SOURCE_EXTENSION_PATH}.`
+    return `[agent-browser-relay] Failed to resolve the Chrome extension files from ${SOURCE_EXTENSION_PATH}.`
   }
   if (result?.copyFailed) {
     return [
-      `[agent-browser-relay] Failed to prepare visible extension folder at ${targetPath}: copy failed.`,
-      `Check that ${VISIBLE_ROOT} is writable and retry.`,
+      `[agent-browser-relay] Failed to prepare the optional visible extension folder at ${targetPath}: copy failed.`,
+      `Load the primary extension path instead: ${primaryPath}.`,
+      `Check that ${VISIBLE_ROOT} is writable and retry \`npm run extension:install\`.`,
     ].join(' ')
   }
-  return `[agent-browser-relay] Failed to prepare visible extension folder at ${targetPath}.`
+  return [
+    `[agent-browser-relay] Failed to prepare the optional visible extension folder at ${targetPath}.`,
+    `Load the primary extension path instead: ${primaryPath}.`,
+  ].join(' ')
+}
+
+function parseCliArgs(args) {
+  const options = {
+    json: false,
+    paths: false,
+  }
+
+  for (const arg of args) {
+    if (arg === '--json') {
+      options.json = true
+      continue
+    }
+    if (arg === '--paths') {
+      options.paths = true
+      continue
+    }
+    if (arg === '-h' || arg === '--help') {
+      options.help = true
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return options
+}
+
+function printPathSummary(result) {
+  console.log('Primary Chrome extension path:')
+  console.log(`  ${result.path}`)
+  console.log(`Primary path source: ${describePrimaryLoadPathKind(result.pathKind)}`)
+
+  if (result.visiblePathReady) {
+    console.log('Optional visible convenience path:')
+    console.log(`  ${result.visiblePath}`)
+  } else {
+    console.log('Optional visible convenience path is not prepared:')
+    console.log(`  ${result.visiblePath}`)
+    console.log('Run `npm run extension:install` from the installed skill directory if you want that shortcut.')
+  }
 }
 
 function runCli() {
-  const result = refreshInstallBundle((message) => {
-    console.error(`[agent-browser-relay] ${message}`)
-  })
-
-  if (result.ok) {
+  let args
+  try {
+    args = parseCliArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
     return
   }
 
-  console.error(describeInstallBundleFailure(result))
-  process.exitCode = 1
+  if (args.help) {
+    console.log('Usage:')
+    console.log('  node scripts/extension-install-helper.js           # prepare optional visible convenience path')
+    console.log('  node scripts/extension-install-helper.js --paths   # print primary extension path to load in Chrome')
+    console.log('  node scripts/extension-install-helper.js --json    # output install status as JSON')
+    return
+  }
+
+  const result = refreshInstallBundle(
+    args.paths || args.json
+      ? () => {}
+      : (message) => {
+          console.error(`[agent-browser-relay] ${message}`)
+        },
+    {
+      prepareVisible: !(args.paths || args.json),
+      printHint: !(args.paths || args.json),
+    },
+  )
+
+  if (args.json) {
+    console.log(`${JSON.stringify(result, null, 2)}\n`)
+  } else if (args.paths) {
+    printPathSummary(result)
+  }
+
+  if (result.sourceMissing) {
+    console.error(describeInstallBundleFailure(result))
+    process.exitCode = 1
+    return
+  }
+
+  if (!args.paths && result.ok !== true) {
+    console.error(describeInstallBundleFailure(result))
+    process.exitCode = 1
+  }
 }
 
 if (require.main === module) {

--- a/scripts/read-active-tab.js
+++ b/scripts/read-active-tab.js
@@ -72,13 +72,19 @@ const options = parseArgs(args)
 let installBundle = {
   ok: false,
   path: null,
+  pathKind: null,
+  sourcePath: null,
+  visiblePath: null,
   installedVersion: null,
+  visibleVersion: null,
   sourceVersion: null,
   relayVersion: null,
   versionMismatch: false,
   updated: false,
   sourceMissing: false,
   copyFailed: false,
+  visiblePathReady: false,
+  visiblePathNeedsRefresh: false,
 }
 
 if (options.help) {
@@ -194,7 +200,12 @@ function getRelaySource() {
     capabilities: SKILL_CAPABILITIES,
     extension: {
       installPath: installBundle.path,
+      loadPath: installBundle.path,
+      loadPathKind: installBundle.pathKind,
+      sourcePath: installBundle.sourcePath,
+      visiblePath: installBundle.visiblePath,
       installedVersion: installBundle.installedVersion,
+      visibleVersion: installBundle.visibleVersion,
       sourceVersion: installBundle.sourceVersion,
       relayVersion: installBundle.relayVersion,
       observedExtensionVersion,
@@ -207,6 +218,8 @@ function getRelaySource() {
       updated: Boolean(installBundle.updated),
       versionMismatch: Boolean(installBundle.versionMismatch || extensionMismatch),
       copyFailed: Boolean(installBundle.copyFailed),
+      visiblePathReady: Boolean(installBundle.visiblePathReady),
+      visiblePathNeedsRefresh: Boolean(installBundle.visiblePathNeedsRefresh),
     },
   }
 }
@@ -1759,13 +1772,19 @@ async function main() {
     installBundle = {
       ok: false,
       path: null,
+      pathKind: null,
+      sourcePath: null,
+      visiblePath: null,
       installedVersion: null,
+      visibleVersion: null,
       sourceVersion: null,
       relayVersion: null,
       versionMismatch: false,
       updated: false,
       sourceMissing: false,
       copyFailed: true,
+      visiblePathReady: false,
+      visiblePathNeedsRefresh: false,
     }
   }
 
@@ -1790,8 +1809,13 @@ async function main() {
     })
     .catch((error) => {
       if (installBundle.copyFailed) {
-        console.error('[agent-browser-relay] Failed to sync the visible extension folder for Chrome install.')
-        console.error(`[agent-browser-relay] Verify write permissions for ${path.join(os.homedir(), 'agent-browser-relay')}.`)
+        console.error('[agent-browser-relay] Failed to refresh the optional visible extension folder for Chrome install.')
+        if (installBundle.path) {
+          console.error(`[agent-browser-relay] Load the primary extension path instead: ${installBundle.path}`)
+        }
+        console.error(
+          `[agent-browser-relay] Verify write permissions for ${path.join(os.homedir(), 'agent-browser-relay')} and rerun \`npm run extension:install\` if you want the visible shortcut.`,
+        )
       }
       if (error && !error.message.includes('ECONNREFUSED')) {
         console.error(`[agent-browser-relay] Relay status check failed: ${error.message}`)

--- a/scripts/relay-manager.js
+++ b/scripts/relay-manager.js
@@ -133,8 +133,8 @@ function prepareVisibleExtensionBundle() {
   } catch (error) {
     console.warn(
       [
-        `[agent-browser-relay] Failed to prepare visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
-        'Relay startup will continue, but the visible Chrome extension folder may be stale or missing.',
+        `[agent-browser-relay] Failed to prepare the optional visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
+        'Relay startup will continue, but the optional visible Chrome extension folder may be stale or missing.',
       ].join(' '),
     )
     return null
@@ -143,7 +143,7 @@ function prepareVisibleExtensionBundle() {
     console.warn(
       [
         describeInstallBundleFailure(result),
-        'Relay startup will continue, but the visible Chrome extension folder may be stale or missing.',
+        'Relay startup will continue, but the optional visible Chrome extension folder may be stale or missing.',
       ].join(' '),
     )
     return result

--- a/scripts/relay-service.js
+++ b/scripts/relay-service.js
@@ -112,8 +112,8 @@ function prepareVisibleExtensionBundle() {
   } catch (error) {
     console.warn(
       [
-        `[agent-browser-relay] Failed to prepare visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
-        'Relay service operations will continue, but the visible Chrome extension folder may be stale or missing.',
+        `[agent-browser-relay] Failed to prepare the optional visible extension folder: ${error instanceof Error ? error.message : String(error)}`,
+        'Relay service operations will continue, but the optional visible Chrome extension folder may be stale or missing.',
       ].join(' '),
     )
     return null
@@ -122,7 +122,7 @@ function prepareVisibleExtensionBundle() {
     console.warn(
       [
         describeInstallBundleFailure(result),
-        'Relay service operations will continue, but the visible Chrome extension folder may be stale or missing.',
+        'Relay service operations will continue, but the optional visible Chrome extension folder may be stale or missing.',
       ].join(' '),
     )
     return result


### PR DESCRIPTION
## Summary
- make the installed skill directory the primary Chrome extension load path instead of assuming `~/agent-browser-relay/extension` exists
- add `npm run extension:path` so humans and agents can print the exact folder to load after `skills add`
- keep `~/agent-browser-relay/extension` as an optional convenience copy created by `npm run extension:install`

## Why this change
- `skills add` reliably installs the skill into `~/.agents/skills/agent-browser-relay`, but it does not create the visible home-folder copy
- the old onboarding flow was built around that visible copy, so fresh installs could still fail even after the earlier startup diagnostics work
- making the installed skill path the source of truth is the robust fix and matches the current `skills` installer contract

## What changed
- rewrote the extension install helper to resolve the real primary load path, report it clearly, and only treat the visible home-folder copy as optional
- added the `extension:path` script and removed the misleading `postinstall` hook that implied `skills add` would prepare the visible copy automatically
- updated relay/read flows so payloads and warnings point to the primary extension path and degrade cleanly when the optional visible copy cannot be refreshed
- updated README, SKILL, AGENTS, and `codex:install` output so future humans and agents are told to load the guaranteed path after `skills add`

## Files changed
- install-path resolution and CLI: `scripts/extension-install-helper.js`, `package.json`
- relay/read messaging and metadata: `scripts/read-active-tab.js`, `scripts/relay-manager.js`, `scripts/relay-service.js`
- setup messaging: `scripts/codex-skill-link.sh`, `README.md`, `SKILL.md`, `AGENTS.md`

## QA / Testing
- Command: `npm run lint` — Result: passed
- Command: `npm run knip` — Result: passed (`knip: not configured for this repository; skipped`)
- Command: `npm run build` — Result: passed
- Command: `HOME=<temp-home> npx -y skills add <local-repo> --skill agent-browser-relay --global --yes` — Result: created `~/.agents/skills/agent-browser-relay/extension` without creating `~/agent-browser-relay/extension`
- Command: `HOME=<temp-home> npm --prefix ~/.agents/skills/agent-browser-relay run extension:path` — Result: printed the canonical installed-skill extension path and reported the visible copy as optional/not prepared
- Command: `HOME=<temp-home> npm --prefix ~/.agents/skills/agent-browser-relay run extension:install` — Result: created `~/agent-browser-relay/extension` on demand
- Command: `HOME=<temp-home> npm --prefix ~/.agents/skills/agent-browser-relay install` then `npm --prefix ~/.agents/skills/agent-browser-relay run relay:start -- --port 18894 --status-timeout-ms 500 --start-timeout-ms 2000` and `relay:stop -- --port 18894` — Result: relay started/stopped successfully from the installed skill copy
- Command: same installed-skill relay start/stop flow with a blocking file at `$HOME/agent-browser-relay` — Result: warned about the optional visible copy failure, still printed the primary path, and still started/stopped successfully

## Risks and impacts
- users who expected `~/agent-browser-relay/extension` to exist automatically after `skills add` now need to run `npm run extension:install` explicitly if they want that convenience path
- the visible copy remains copy-based rather than symlink-based by design; the primary reliability fix is to stop depending on it for first-run onboarding

## Rollback plan
- revert commit `ea8b7fd`
- if needed, restore the previous helper behavior and docs while investigating a different distribution strategy for the visible copy

## Related issues
- Fixes #21

## Checklist
- [x] Tests pass
- [x] No obvious regressions
- [x] Documentation updated where needed
- [x] Rollback path documented
