### PR TITLE
Release 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to Agent Browser Relay are tracked here.
 
 ## [Unreleased]
 
+- No unreleased entries yet.
+
+## [0.0.13] - 2026-04-02
+
+### Added
+
+- Added a top-level `CHANGELOG.md` so shipped release history lives in the repo instead of only in GitHub releases.
+
 ### Changed
 
 - Refreshed the extension icon set with a simpler dark monogram mark that matches the popup and options page styling more closely.
+- Improved the Agent Browser Relay skill trigger metadata and `agents/openai.yaml` invocation guidance so the skill is easier to discover and invoke correctly.
 
 ## [0.0.12] - 2026-04-02
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent Browser Relay",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Attach Agent Browser Relay to your existing Chrome tab via a local CDP relay server.",
   "icons": {
     "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-browser-relay",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-browser-relay",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "hasInstallScript": true,
       "dependencies": {
         "ws": "^8.18.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-browser-relay",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "bin": {
     "agent-browser-relay": "relay-server.js"
   },


### PR DESCRIPTION
## Summary
- bump package and extension version to `0.0.13`
- roll the current unreleased changelog items into a `0.0.13` entry
- reset `Unreleased` after the release cut

## Validation
- `pnpm build`
- `pnpm lint`