### PR TITLE
feat(relay): support multi-browser clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,12 @@ This repository provides a local browser-relay so an agent can attach to a **cho
 ## Capabilities
 - Attach or detach the chosen tab from the toolbar popup.
 - Keep multiple tabs attached concurrently in one extension instance.
+- Keep multiple browser/profile extension clients connected concurrently on one relay port.
 - Recover/reconnect when tab context changes.
 - Spawn a new background tab via CDP (`Target.createTarget`) and auto-attach it through the extension bridge.
 - Execute JavaScript in-page via CDP (`Runtime.evaluate`).
 - Capture screenshots from the attached tab (`--screenshot`, optional `--screenshot-full-page`).
-- Relay session/lease isolation for multi-agent workflows (`--tab-id`).
+- Relay session/lease isolation for multi-agent workflows (`--tab-id`, `--tab-ref`).
 - Default extraction payload: `url`, `title`, `text`, `links`, `metaDescription`.
 - Full DOM extraction with custom expression (e.g. `document.documentElement.outerHTML`).
 - WhatsApp chat extraction using the `--preset whatsapp-messages` mode.
@@ -124,12 +125,14 @@ This refreshes sparse state and restores all missing tracked directories in the 
      - Open/focus the target tab in Chrome.
      - Open the toolbar popup and click **Attach this tab** so the badge shows `ON`.
    - The agent must wait for human confirmation before continuing.
-   - Resolve the target `tabId` from relay status (`/status` or `npm run relay:status -- --all --status-timeout-ms 3000`).
+   - Resolve the target `tabId` or `tabRef` from relay status (`/status` or `npm run relay:status -- --all --status-timeout-ms 3000`).
    - Before any read, the agent must run:
 
    ```bash
    npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json
    ```
+
+   Use `--tab-ref "<TAB_REF>"` instead when multiple browsers expose the same numeric tab id.
 
    If the workflow will open new tabs via `Target.createTarget`, also run:
 
@@ -139,7 +142,14 @@ This refreshes sparse state and restores all missing tracked directories in the 
 
    Continue only when this check succeeds.
 
-### Per-tab relay port behavior
+### Multi-browser behavior
+- One relay port supports multiple connected browser/profile extension clients.
+- Relay status exposes connected `browsers[]` and browser-scoped attached tab refs.
+- Attached tabs include `tabRef` formatted as `browserId:tabId`.
+- Use `--tab-id` when the numeric tab id is unambiguous; use `--tab-ref` when multiple browsers may expose the same numeric tab id.
+- If multiple browsers allow `Target.createTarget`, use `--browser-id` to choose the browser.
+
+### Advanced per-tab relay port behavior
 - If you start relay on multiple ports, one extension install can manage different ports by tab.
 - If a tab has no saved relay-port mapping, it uses the global default relay port (`18793`).
 - On successful attach, the extension stores that tab’s relay port mapping.
@@ -166,12 +176,12 @@ This refreshes sparse state and restores all missing tracked directories in the 
 - If the current working directory is not the installed skill root, agent must use the stable absolute `read-active-tab.js` path printed by `npm run extension:path` instead of assuming `node scripts/read-active-tab.js` is valid from the current cwd.
 - After relay startup (`relay:global:start` / `relay:global:install` or `relay:start`), agent must stop and ask the human to open the popup once, then run `npm run extension:status -- --wait-for-connected --connected-timeout-ms 120000`.
 - Only after `extension:status` succeeds may the agent either ask the human to attach the target tab, or rely on enabled target-create permission for first-tab creation workflows.
-- Agent must run `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json` before any data read and continue only on success.
+- Agent must run `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json` or `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-ref "<TAB_REF>" --json` before any data read and continue only on success.
 - For workflows that create tabs with `Target.createTarget`, agent must additionally require target-create readiness via `--require-target-create`.
 - When target-create readiness succeeds, the extension may create and auto-attach the first agent-controlled tab for that session even when no tab lease exists yet.
-- For all agent runs (single-agent and concurrent), agent must use tab leasing by setting `--tab-id <tabId>` on all read/check commands.
-- Agent must resolve `tabId` from relay status (`/status` or `npm run relay:status -- --all`) and explicitly target that tab.
-- If the requested `tabId` is not present in status `attachedTabs`, agent must stop and ask the human to re-attach that tab before continuing.
+- For all agent runs (single-agent and concurrent), agent must use tab leasing by setting `--tab-id <tabId>` or `--tab-ref <browserId:tabId>` on all read/check commands.
+- Agent must resolve `tabId` or `tabRef` from relay status (`/status` or `npm run relay:status -- --all`) and explicitly target that tab.
+- If the requested `tabId`/`tabRef` is not present in status `attachedTabs`, agent must stop and ask the human to re-attach that tab before continuing.
 - Agent must not stop/restart relay during a task unless the human explicitly asks for restart or a hard failure requires it.
 - Agent must not restart relay only because local code changed. Code updates are picked up only on explicit human-approved restart.
 - If the page shows human-verification gates (for example "Are you human?" or CAPTCHA), agent must stop immediately, alert the human with [$attention-please](/Users/mathiasasberg/.codex/skills/public/attention-please/SKILL.md), and wait for explicit human confirmation before continuing.
@@ -205,7 +215,7 @@ Never run bare `curl` without a timeout for relay checks.
 
    If relay is reachable this command returns a structured blocker with the next action instead of a generic attach timeout.
 
-   Agent safety note: autonomous runs must use commands that include `--tab-id "<TAB_ID>"`. Unscoped variants below are manual/debug-only.
+   Agent safety note: autonomous runs must use commands that include `--tab-id "<TAB_ID>"` or `--tab-ref "<TAB_REF>"`. Unscoped variants below are manual/debug-only.
 
 6. Read default extraction from a specific leased tab:
 
@@ -273,7 +283,8 @@ Never run bare `curl` without a timeout for relay checks.
 - `--wait-for-attach` waits for the bridge and tab attachment before running reads.
 - `--attach-timeout-ms <ms>` controls the max wait time (default: `120000`).
 - `--attach-poll-ms <ms>` controls retry frequency (default: `500`).
-- `--tab-id <id>` enables relay session lease routing so each agent is isolated to a specific tab.
+- `--tab-id <id>` enables relay session lease routing when the numeric tab id is unambiguous.
+- `--tab-ref <browserId:tabId>` enables relay session lease routing for a specific browser/profile tab.
 
 When check/read succeeds, payload includes:
 `source.relayHost`, `source.relayPort`, `source.relayStatusUrl`, and `source.relayWebSocketUrl` so humans can confirm the active relay endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Agent Browser Relay are tracked here.
 
 - No unreleased entries yet.
 
+## [0.0.14] - 2026-06-09
+
+### Added
+
+- Added multi-browser relay hub support so one relay port can keep multiple browser/profile extension clients connected concurrently.
+- Added browser-scoped `tabRef` values (`browserId:tabId`) in relay status and lease routing for duplicate numeric tab ids across browsers.
+- Added `--tab-ref` and `--browser-id` support for relay doctor/read workflows.
+
+### Changed
+
+- Updated status, popup, README, skill, and agent guidance for seamless one-port multi-browser operation.
+
 ## [0.0.13] - 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ Use it when an agent needs page text, links, DOM, screenshots, or selected brows
 
 ## How It Works
 
-1. A Chrome extension lets you attach the tab you want the agent to use.
+1. A Chrome or Chromium extension lets you attach the tab you want the agent to use.
 2. A local relay runs on `127.0.0.1:18793`.
-3. The agent calls the relay with a specific `--tab-id`.
-4. The relay reads only that attached tab and returns JSON.
+3. One relay port can keep multiple browser/profile extension clients connected at once.
+4. The agent calls the relay with a specific `--tab-id` or browser-scoped `--tab-ref`.
+5. The relay reads only that attached tab and returns JSON.
 
 The important safety rule is simple: no attached tab, no read.
 
 ## Requirements
 
-- Google Chrome
+- Google Chrome or another Chromium browser that can load unpacked extensions
 - Node.js 20 or newer
 - `pnpm`
 - macOS or Linux for the global background relay service
@@ -83,11 +84,11 @@ pnpm extension:status -- --wait-for-connected --connected-timeout-ms 120000
 
 ## Attach A Tab
 
-1. Open the target page in Chrome.
+1. Open the target page in Chrome, Brave, Edge, or another Chromium browser.
 2. Click the **Agent Browser Relay** toolbar icon.
 3. Click **Attach this tab**.
 4. Confirm the badge shows `ON`.
-5. Copy the tab id from the popup, or get it from:
+5. Copy the tab id from the popup, or get the tab id / tab ref from:
 
 ```bash
 pnpm relay:status -- --all --status-timeout-ms 3000
@@ -95,12 +96,18 @@ pnpm relay:status -- --all --status-timeout-ms 3000
 
 ## Read A Tab
 
-Replace `<TAB_ID>` with the attached tab id.
+Replace `<TAB_ID>` with the attached tab id. If more than one browser is connected and tab ids collide, use `<TAB_REF>` from `relay:status` instead. A tab ref is `browserId:tabId`.
 
 Run the readiness check first:
 
 ```bash
 pnpm relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json
+```
+
+Or target a specific browser tab ref:
+
+```bash
+pnpm relay:doctor -- --host "127.0.0.1" --port "18793" --tab-ref "<TAB_REF>" --json
 ```
 
 Read the default page payload:
@@ -110,6 +117,16 @@ node scripts/read-active-tab.js \
   --host "127.0.0.1" \
   --port "18793" \
   --tab-id "<TAB_ID>" \
+  --pretty false
+```
+
+For duplicate tab ids across browsers:
+
+```bash
+node scripts/read-active-tab.js \
+  --host "127.0.0.1" \
+  --port "18793" \
+  --tab-ref "<TAB_REF>" \
   --pretty false
 ```
 
@@ -157,7 +174,7 @@ The agent should:
 
 1. Check relay status.
 2. Confirm the requested tab is attached.
-3. Run `relay:doctor` for that `--tab-id`.
+3. Run `relay:doctor` for that `--tab-id` or `--tab-ref`.
 4. Read only that tab.
 
 ## Agent Safety Contract
@@ -167,7 +184,9 @@ Agents must use the local relay gateway only:
 - `/status`
 - `pnpm relay:status -- --all --status-timeout-ms 3000`
 - `pnpm relay:doctor -- --tab-id "<TAB_ID>" --json`
+- `pnpm relay:doctor -- --tab-ref "<TAB_REF>" --json`
 - `node scripts/read-active-tab.js --tab-id "<TAB_ID>"`
+- `node scripts/read-active-tab.js --tab-ref "<TAB_REF>"`
 
 Agents must not use Playwright, Puppeteer, Selenium, ad-hoc Chrome scripts, or a random Chrome profile for this workflow.
 
@@ -205,7 +224,7 @@ Tab is not attached:
 1. Focus the tab in Chrome.
 2. Open the extension popup.
 3. Click **Attach this tab** again.
-4. Re-run `pnpm relay:doctor -- --tab-id "<TAB_ID>" --json`.
+4. Re-run `pnpm relay:doctor -- --tab-id "<TAB_ID>" --json` or `pnpm relay:doctor -- --tab-ref "<TAB_REF>" --json`.
 
 Another agent has the tab lease:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Read metadata, DOM, screenshots, and structured page payloads from 
 
 Use this skill to operate through the local relay gateway on an explicitly attached browser tab, verify readiness before reads, and keep concurrent tab workflows lease-scoped instead of falling back to direct browser-control tools.
 
-Chrome is the documented target. Chromium-based browsers that can load the extension may also work, and relay status now surfaces detected host-browser identity plus a persistent profile id, but the skill does not yet provide first-class multi-browser orchestration.
+Chrome is the documented primary target. Chromium-based browsers that can load the extension may also work. One relay port can keep multiple browser/profile extension clients connected concurrently, and relay status exposes each browser id plus attached `tabRef` values.
 
 ## Quick start
 
@@ -65,11 +65,11 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
    npm run extension:status -- --port "18793" --wait-for-connected --connected-timeout-ms 120000
    ```
 
-   This now also reports the detected browser host and persistent profile id for the connected extension instance.
+   This reports each connected browser host/profile id for the relay port.
 
 4. Attach the extension to the target tab (open toolbar popup and click attach)
 
-   Optional per-tab relay: in the popup, set **Tab port** before clicking attach if this tab should use a non-default relay port.
+   In normal use, keep every browser on the default relay port and attach the target tab in each browser. The relay namespaces tabs by `tabRef` (`browserId:tabId`).
    If you want the agent to create its own first background tab instead, enable **Allow agent to create new background tabs** in the popup.
 
    Agent requirement: after `extension:status` confirms Chrome loaded the extension, pause and ask the human to do this attach step, then wait for confirmation before continuing.
@@ -90,28 +90,37 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
    npm run relay:doctor -- --port "18793" --tab-id "<TAB_ID>" --json
    ```
 
-   Resolve `<TAB_ID>` from status first (`npm run relay:status -- --all --status-timeout-ms 3000`).
-   For all agent runs, use the assigned tab id:
+   Resolve `<TAB_ID>` or `<TAB_REF>` from status first (`npm run relay:status -- --all --status-timeout-ms 3000`).
+   For all agent runs, use the assigned tab id or tab ref:
 
    ```bash
    npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json
    ```
 
+   ```bash
+   npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-ref "<TAB_REF>" --json
+   ```
+
    Continue only if this command returns success.
 
-### Per-tab relay port behavior
-- If you run one relay process with multiple ports, the extension can manage different relay ports per attached tab.
+### Multi-browser behavior
+- One relay port supports multiple connected browser/profile extension clients.
+- Attached tabs include a browser-scoped `tabRef` formatted as `browserId:tabId`.
+- Use `--tab-id` when only one attached tab has that id; use `--tab-ref` when multiple browsers may expose the same numeric tab id.
+- If `Target.createTarget` is enabled in more than one browser, pass `--browser-id` to choose the browser.
+
+### Advanced per-tab relay port behavior
+- Multiple relay ports remain available for debugging or special routing.
 - A tab with no saved relay-port mapping uses the global default relay port (`18793`).
 - After a successful attach, the extension saves that tab’s mapped relay port and reuses it automatically.
 - Closed tabs have their mapping removed automatically.
-- This is per-tab port routing, not first-class multi-browser support.
 
 
 ## Mandatory behavior for agents
 - Use fixed commands from this repo. Do not try to "discover" alternate script names.
 - Gateway-only rule: always communicate through the local relay gateway (`/status` and `node scripts/read-active-tab.js`).
 - Never use direct browser-control tooling for this workflow (for example Playwright, Puppeteer, Selenium, `agent-browser`, or ad-hoc Chrome control scripts).
-- Never take control of a random Chrome window/profile. Only operate on the explicitly attached target tab leased via `--tab-id`.
+- Never take control of a random Chrome window/profile. Only operate on the explicitly attached target tab leased via `--tab-id` or `--tab-ref`.
 - On a fresh machine, explicitly tell the human to load the primary extension path from `npm run extension:path` before any attach/read attempt. After `skills add`, that is normally `~/.agents/skills/agent-browser-relay/extension`.
 - Canonical commands:
   - `npm run extension:path`
@@ -127,10 +136,10 @@ Override per command with `--host`, `--port`, and `--attach-timeout-ms` when nee
   - `npm run relay:status -- --all --status-timeout-ms 3000`
 - After `relay:start`, pause and ask the human to open the popup once so `npm run extension:status -- --port "18793" --wait-for-connected --connected-timeout-ms 120000` can confirm Chrome actually loaded the extension.
 - Only after `extension:status` succeeds, either ask the human to attach the target tab before reads, or confirm that **Allow agent to create new background tabs** is enabled before first-tab creation workflows.
-- Run `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json` before reads and proceed only when it succeeds.
+- Run `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-id "<TAB_ID>" --json` or `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --tab-ref "<TAB_REF>" --json` before reads and proceed only when it succeeds.
 - If the workflow will open tabs via `Target.createTarget`, run `npm run relay:doctor -- --host "127.0.0.1" --port "18793" --require-target-create --json` and proceed only when it succeeds.
-- For all agent runs (single-agent and concurrent), always pass `--tab-id <tabId>` on check/read commands so every operation is lease-scoped.
-- In concurrent runs, attached tabs are shared extension state, but an attached tab can only have one active lease at a time. Inspect `npm run relay:status -- --all --status-timeout-ms 3000` and prefer `leaseSummary.availableAttachedTabIds` or `attachedTabs[].leasedSessionId` when choosing the next `--tab-id`.
+- For all agent runs (single-agent and concurrent), always pass `--tab-id <tabId>` or `--tab-ref <browserId:tabId>` on check/read commands so every operation is lease-scoped.
+- In concurrent runs, attached tabs are shared relay state, but an attached tab can only have one active lease at a time. Inspect `npm run relay:status -- --all --status-timeout-ms 3000` and prefer `leaseSummary.availableAttachedTabIds`, `attachedTabs[].tabRef`, or `attachedTabs[].leasedSessionId` when choosing the next `--tab-id` / `--tab-ref`.
 - If doctor returns `TAB_LEASED_BY_OTHER_SESSION`, do not attempt takeover. Wait for that session to finish or retry with another attached tab that has no active lease.
 - When `Target.createTarget` is enabled, the extension may create and auto-attach the first agent-controlled tab for the session without a human seed attach step.
 - Do not stop/restart relay during the task unless the human requests it or recovery is explicitly required.
@@ -171,7 +180,7 @@ Version compatibility checks are also included under `source.extension`:
 If a mismatch is detected, the command also prints a human-friendly update hint to stderr on every run.
 
 - `scripts/read-active-tab.js` default extraction: `url`, `title`, `text`, `links`, `metaDescription`.
-- Relay session leases (`--tab-id`) for concurrent agent isolation per tab on one relay port.
+- Relay session leases (`--tab-id`, `--tab-ref`) for concurrent agent isolation per tab on one relay port.
 - `Runtime.evaluate` expression mode with `--expression`, `--expression-file`, or `--expression-stdin`.
 - Screenshot capture mode via `--screenshot` (optional `--screenshot-full-page`, `--screenshot-path`).
 - Preset extraction for WhatsApp and generic chat-auditing with regex filters.
@@ -192,12 +201,13 @@ If a mismatch is detected, the command also prints a human-friendly update hint 
 
 ## Common command examples
 
-In agent workflows, use the `--tab-id` variants. Unscoped commands are for manual/local debugging only.
+In agent workflows, use the `--tab-id` or `--tab-ref` variants. Unscoped commands are for manual/local debugging only.
 Prefer `--expression-file` or `--expression-stdin` over inline `--expression` for non-trivial JavaScript.
 
 ```bash
 node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --pretty false
 node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id 123 --pretty false
+node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-ref chrome-profile:123 --pretty false
 node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id 123 --check --wait-for-attach --require-target-create --attach-timeout-ms 120000
 node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --expression "document.documentElement.outerHTML"
 node scripts/read-active-tab.js --host "127.0.0.1" --port "18793" --tab-id 123 --expression-file "./tmp/expression.js"
@@ -216,6 +226,6 @@ Before fetching data in an automation flow, run a lightweight preflight once to 
 For multiple agents on one relay:
 - Resolve tab ids from relay status (`npm run relay:status -- --all --status-timeout-ms 3000`).
 - Assign one tab id per agent.
-- Use `--tab-id` in every `read-active-tab.js` call for that agent.
+- Use `--tab-id` or `--tab-ref` in every `read-active-tab.js` call for that agent.
 - Treat the extension instance as shared: leases prevent two controller sessions from driving the same attached tab, but they do not create separate Chrome profiles or separate extension processes.
 - If `relay:doctor` reports `TAB_LEASED_BY_OTHER_SESSION`, inspect `attachedTabs`, `tabLeases`, and blocker `detail`, then pick another attached tab or wait for the owning session to release it.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent Browser Relay",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Attach Agent Browser Relay to your existing Chrome tab via a local CDP relay server.",
   "icons": {
     "16": "icons/icon16.png",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -328,7 +328,7 @@
           <h1>Agent Browser Relay</h1>
           <div class="topbarRight">
             <button id="openExtensionTab" type="button">Open tab</button>
-            <div class="version">v0.0.11</div>
+            <div id="version" class="version"></div>
           </div>
         </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -10,10 +10,17 @@ const attachButton = document.getElementById('attach')
 const refreshButton = document.getElementById('refresh')
 const openExtensionTabButton = document.getElementById('openExtensionTab')
 const allowCreateTargetToggle = document.getElementById('allowCreateTarget')
+const versionEl = document.getElementById('version')
 
 function setStatus(message) {
   if (!statusEl) return
   statusEl.textContent = message || ''
+}
+
+function renderVersion() {
+  if (!versionEl || typeof chrome?.runtime?.getManifest !== 'function') return
+  const manifest = chrome.runtime.getManifest()
+  versionEl.textContent = manifest?.version ? `v${manifest.version}` : ''
 }
 
 function setRoutingExpanded(expanded) {
@@ -307,4 +314,5 @@ attachButton?.addEventListener('click', () => void onToggleAttach())
 allowCreateTargetToggle?.addEventListener('change', () => void onToggleAllowCreateTarget())
 
 setRoutingExpanded(false)
+renderVersion()
 void refresh()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-browser-relay",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Chrome extension and local relay for tab-scoped agent browser reads.",
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/relay-server.js
+++ b/relay-server.js
@@ -90,13 +90,14 @@ function createPortState(relayPort) {
   return {
     relayPort,
     extensionSocket: null,
+    extensionClientsById: new Map(),
     controllerSockets: new Set(),
     pendingByRelayId: new Map(),
     queuedControllerRequests: [],
     nextRelayId: 1,
+    nextExtensionClientId: 1,
     extensionLastSeenTs: 0,
     extensionHeartbeatState: null,
-    extensionSessionToTab: new Map(),
     sessionsById: new Map(),
     tabLeases: new Map(),
     nextSessionId: 1,
@@ -113,18 +114,130 @@ function getPortState(relayPort) {
 function countConnectedControllerClients(state) {
   let count = 0
   for (const socket of state.controllerSockets) {
-    if (!socket || socket === state.extensionSocket) continue
+    const entry = socketMeta.get(socket)
+    if (!socket || entry?.role === 'extension') continue
     if (socket.readyState !== socket.OPEN) continue
     count += 1
   }
   return count
 }
 
+function isSocketOpen(socket) {
+  return Boolean(socket && socket.readyState === socket.OPEN)
+}
+
+function sanitizeBrowserId(value) {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  return raw.replace(/[^a-zA-Z0-9_.-]/g, '_')
+}
+
+function browserIdFromIdentity(browser, fallback) {
+  return sanitizeBrowserId(browser?.profileId) || sanitizeBrowserId(fallback)
+}
+
+function createFallbackBrowserId(state) {
+  const suffix = state.nextExtensionClientId
+  state.nextExtensionClientId += 1
+  return `browser-${state.relayPort}-${suffix}`
+}
+
+function createTabRef(browserId, tabId) {
+  const safeBrowserId = sanitizeBrowserId(browserId)
+  const safeTabId = parseTabId(tabId)
+  if (!safeBrowserId || !safeTabId) return null
+  return `${safeBrowserId}:${safeTabId}`
+}
+
+function parseTabRef(value) {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  const splitAt = raw.lastIndexOf(':')
+  if (splitAt <= 0 || splitAt === raw.length - 1) return null
+  const browserId = sanitizeBrowserId(raw.slice(0, splitAt))
+  const tabId = parseTabId(raw.slice(splitAt + 1))
+  if (!browserId || !tabId) return null
+  return { browserId, tabId, tabRef: createTabRef(browserId, tabId) }
+}
+
+function listExtensionClients(state) {
+  return Array.from(state.extensionClientsById.values())
+    .filter((client) => isSocketOpen(client.socket))
+    .sort((a, b) => String(a.browserId).localeCompare(String(b.browserId)))
+}
+
+function findExtensionClientBySocket(state, socket) {
+  for (const client of state.extensionClientsById.values()) {
+    if (client.socket === socket) return client
+  }
+  return null
+}
+
+function getPrimaryExtensionClient(state) {
+  const clients = listExtensionClients(state)
+  if (clients.length === 0) return null
+  return clients.sort((a, b) => b.lastSeenTs - a.lastSeenTs)[0]
+}
+
+function syncLegacyExtensionState(state) {
+  const primary = getPrimaryExtensionClient(state)
+  state.extensionSocket = primary?.socket || null
+  state.extensionLastSeenTs = primary?.lastSeenTs || 0
+  state.extensionHeartbeatState = primary?.heartbeatState || null
+}
+
+function mostRecentSeenAgo(entries) {
+  const ages = entries
+    .map((entry) => Number(entry.extensionLastSeenAgoMs))
+    .filter((age) => Number.isFinite(age))
+  if (ages.length === 0) return null
+  return Math.min(...ages)
+}
+
+function summarizeBrowserClient(state, client) {
+  const heartbeat = client.heartbeatState || {}
+  const extensionLastSeenAgoMs = client.lastSeenTs ? Date.now() - client.lastSeenTs : null
+  const attachedTabs = listAttachedTabsForClient(state, client)
+  const attachedLeases = attachedTabs
+    .filter((tab) => typeof tab?.leasedSessionId === 'string' && tab.leasedSessionId.length > 0)
+    .map(({ tabRef, tabId, browserId, leasedSessionId }) => ({ tabRef, tabId, browserId, sessionId: leasedSessionId }))
+  return {
+    browserId: client.browserId,
+    extensionConnected: isSocketOpen(client.socket),
+    extensionLastSeenAgoMs,
+    activeTab: decorateTabMeta(heartbeat.activeTab, client),
+    attachedTabs,
+    attachedTabCount: attachedTabs.length,
+    attachedLeaseCount: attachedLeases.length,
+    tabLeases: attachedLeases,
+    extensionVersion: heartbeat.extensionVersion || null,
+    extensionName: heartbeat.extensionName || null,
+    browser: client.browser || null,
+    extensionCapabilities: heartbeat.extensionCapabilities || null,
+    allowTargetCreate:
+      typeof heartbeat.allowTargetCreate === 'boolean'
+        ? heartbeat.allowTargetCreate
+        : null,
+  }
+}
+
+function decorateTabMeta(tab, client) {
+  const base = cleanTabMeta(tab)
+  if (!base) return null
+  const tabRef = createTabRef(client.browserId, base.tabId)
+  return {
+    ...base,
+    browserId: client.browserId,
+    tabRef,
+    browser: client.browser || null,
+  }
+}
+
 function summarizeLeaseVisibility(state) {
   const attachedTabs = listAttachedTabsWithLease(state)
   const attachedLeases = attachedTabs
     .filter((tab) => typeof tab?.leasedSessionId === 'string' && tab.leasedSessionId.length > 0)
-    .map(({ tabId, leasedSessionId }) => ({ tabId, sessionId: leasedSessionId }))
+    .map(({ tabRef, tabId, browserId, leasedSessionId }) => ({ tabRef, tabId, browserId, sessionId: leasedSessionId }))
   const staleTabLeases = summarizeStaleTabLeases(state, attachedTabs)
 
   return {
@@ -139,13 +252,17 @@ function summarizeLeaseVisibility(state) {
 }
 
 function summarizePortState(state) {
-  const extensionConnected = Boolean(state.extensionSocket && state.extensionSocket.readyState === state.extensionSocket.OPEN)
-  const extensionLastSeenAgoMs = state.extensionLastSeenTs ? Date.now() - state.extensionLastSeenTs : null
+  syncLegacyExtensionState(state)
+  const browsers = listExtensionClients(state).map((client) => summarizeBrowserClient(state, client))
+  const extensionConnected = browsers.length > 0
+  const extensionLastSeenAgoMs = mostRecentSeenAgo(browsers)
   const leaseState = summarizeLeaseVisibility(state)
 
   return {
     port: state.relayPort,
     extensionConnected,
+    browserCount: browsers.length,
+    browsers,
     extensionLastSeenAgoMs,
     queuedControllerCommands: state.queuedControllerRequests.length,
     connectedControllerClients: countConnectedControllerClients(state),
@@ -175,6 +292,10 @@ function summarizePortState(state) {
 }
 
 function getSinglePortStatus(state) {
+  syncLegacyExtensionState(state)
+  const browsers = listExtensionClients(state).map((client) => summarizeBrowserClient(state, client))
+  const extensionConnected = browsers.length > 0
+  const extensionLastSeenAgoMs = mostRecentSeenAgo(browsers)
   const leaseState = summarizeLeaseVisibility(state)
 
   return {
@@ -182,8 +303,10 @@ function getSinglePortStatus(state) {
     service: 'grais-debugger-relay',
     host,
     port: state.relayPort,
-    extensionConnected: Boolean(state.extensionSocket && state.extensionSocket.readyState === state.extensionSocket.OPEN),
-    extensionLastSeenAgoMs: state.extensionLastSeenTs ? Date.now() - state.extensionLastSeenTs : null,
+    extensionConnected,
+    browserCount: browsers.length,
+    browsers,
+    extensionLastSeenAgoMs,
     queuedControllerCommands: state.queuedControllerRequests.length,
     connectedControllerClients: countConnectedControllerClients(state),
     pendingCommands: state.pendingByRelayId.size,
@@ -212,17 +335,23 @@ function getSinglePortStatus(state) {
 
 function summarizeTabLeases(state) {
   const leases = []
-  for (const [tabId, sessionId] of state.tabLeases.entries()) {
-    leases.push({ tabId, sessionId })
+  for (const [tabRef, sessionId] of state.tabLeases.entries()) {
+    const parsed = parseTabRef(tabRef)
+    leases.push({
+      tabRef,
+      tabId: parsed?.tabId || null,
+      browserId: parsed?.browserId || null,
+      sessionId,
+    })
   }
-  leases.sort((a, b) => a.tabId - b.tabId)
+  leases.sort((a, b) => String(a.tabRef).localeCompare(String(b.tabRef)))
   return leases
 }
 
 function summarizeStaleTabLeases(state, attachedTabs = null) {
   const attached = Array.isArray(attachedTabs) ? attachedTabs : listAttachedTabsWithLease(state)
-  const attachedTabIds = new Set(attached.map((tab) => tab.tabId).filter((tabId) => Number.isInteger(tabId)))
-  return summarizeTabLeases(state).filter((lease) => !attachedTabIds.has(lease.tabId))
+  const attachedTabRefs = new Set(attached.map((tab) => tab.tabRef).filter(Boolean))
+  return summarizeTabLeases(state).filter((lease) => !attachedTabRefs.has(lease.tabRef))
 }
 
 function getStatusPayload(targetPort = null, preferAll = false) {
@@ -317,14 +446,17 @@ async function removeRelayPorts(portsToRemove) {
     const state = portStates.get(port)
     if (!state) continue
 
-    if (state.extensionSocket && state.extensionSocket.readyState === state.extensionSocket.OPEN) {
-      state.extensionSocket.close(1000, 'relay port removed')
+    for (const client of state.extensionClientsById.values()) {
+      if (isSocketOpen(client.socket)) {
+        client.socket.close(1000, 'relay port removed')
+      }
     }
 
     for (const controller of state.controllerSockets) {
       controller.close(1000, 'relay port removed')
     }
     state.controllerSockets.clear()
+    state.extensionClientsById.clear()
 
     failPending(state, 'Relay port removed')
     clearQueue(state)
@@ -380,12 +512,14 @@ function getSessionForSocket(state, socket) {
 }
 
 function releaseSessionTabLease(state, session) {
-  if (!session || !Number.isInteger(session.leasedTabId)) return
-  const activeSessionId = state.tabLeases.get(session.leasedTabId)
+  if (!session || !session.leasedTabRef) return
+  const activeSessionId = state.tabLeases.get(session.leasedTabRef)
   if (activeSessionId === session.sessionId) {
-    state.tabLeases.delete(session.leasedTabId)
+    state.tabLeases.delete(session.leasedTabRef)
   }
+  session.leasedTabRef = null
   session.leasedTabId = null
+  session.leasedBrowserId = null
 }
 
 function closeSession(state, session, reason = 'Session closed') {
@@ -401,40 +535,124 @@ function closeSessionForSocket(state, socket, reason = 'Session closed') {
   closeSession(state, session, reason)
 }
 
-function claimTabLease(state, session, tabId, force = false) {
+function resolveTabReference(state, target) {
+  const params = typeof target === 'object' && target !== null ? target : { tabId: target }
+  const explicitTabRef = parseTabRef(params.tabRef)
+  if (explicitTabRef) return { ok: true, ...explicitTabRef }
+
+  const tabId = parseTabId(params.tabId)
+  if (!tabId) {
+    return { ok: false, error: 'tabId must be a positive integer or tabRef must be provided' }
+  }
+
+  const requestedBrowserId = sanitizeBrowserId(params.browserId)
+  if (requestedBrowserId) {
+    const client = state.extensionClientsById.get(requestedBrowserId)
+    if (!client || !isSocketOpen(client.socket)) {
+      return { ok: false, error: `Browser ${requestedBrowserId} is not connected on relay port ${state.relayPort}` }
+    }
+    return {
+      ok: true,
+      browserId: requestedBrowserId,
+      tabId,
+      tabRef: createTabRef(requestedBrowserId, tabId),
+    }
+  }
+
+  const attachedMatches = listAttachedTabsWithLease(state).filter((tab) => tab.tabId === tabId)
+  const uniqueAttachedRefs = [...new Set(attachedMatches.map((tab) => tab.tabRef).filter(Boolean))]
+  if (uniqueAttachedRefs.length === 1) {
+    const parsed = parseTabRef(uniqueAttachedRefs[0])
+    return { ok: true, ...parsed }
+  }
+  if (uniqueAttachedRefs.length > 1) {
+    return {
+      ok: false,
+      error: `Tab id ${tabId} is attached in multiple browsers. Use tabRef (${uniqueAttachedRefs.join(', ')}) or pass browserId.`,
+    }
+  }
+
+  const clients = listExtensionClients(state)
+  if (clients.length === 1) {
+    return {
+      ok: true,
+      browserId: clients[0].browserId,
+      tabId,
+      tabRef: createTabRef(clients[0].browserId, tabId),
+    }
+  }
+  if (clients.length > 1) {
+    return {
+      ok: false,
+      error: `Tab id ${tabId} is not attached yet and ${clients.length} browsers are connected. Pass browserId or tabRef.`,
+    }
+  }
+
+  return { ok: false, error: 'No browser extension is connected' }
+}
+
+function claimTabLease(state, session, target, force = false) {
   if (!session) {
     return { ok: false, error: 'Session is required to claim a tab lease' }
   }
-  const normalizedTabId = parseTabId(tabId)
-  if (!normalizedTabId) {
-    return { ok: false, error: 'tabId must be a positive integer' }
+  const resolved = resolveTabReference(state, target)
+  if (!resolved.ok) {
+    return { ok: false, error: resolved.error }
   }
-  const existingSessionId = state.tabLeases.get(normalizedTabId)
+  const { tabRef, tabId, browserId } = resolved
+  const existingSessionId = state.tabLeases.get(tabRef)
   if (existingSessionId && existingSessionId !== session.sessionId) {
     if (!force) {
       return {
         ok: false,
-        error: `Tab ${normalizedTabId} is already leased by session ${existingSessionId}. Choose another attached tab or wait for that session to release it.`,
+        error: `Tab ${tabRef} is already leased by session ${existingSessionId}. Choose another attached tab or wait for that session to release it.`,
       }
     }
     const existingSession = state.sessionsById.get(existingSessionId)
     if (existingSession) {
+      existingSession.leasedTabRef = null
       existingSession.leasedTabId = null
+      existingSession.leasedBrowserId = null
     }
-    state.tabLeases.delete(normalizedTabId)
+    state.tabLeases.delete(tabRef)
   }
 
-  if (Number.isInteger(session.leasedTabId) && session.leasedTabId !== normalizedTabId) {
-    state.tabLeases.delete(session.leasedTabId)
+  if (session.leasedTabRef && session.leasedTabRef !== tabRef) {
+    state.tabLeases.delete(session.leasedTabRef)
   }
-  state.tabLeases.set(normalizedTabId, session.sessionId)
-  session.leasedTabId = normalizedTabId
+  state.tabLeases.set(tabRef, session.sessionId)
+  session.leasedTabRef = tabRef
+  session.leasedTabId = tabId
+  session.leasedBrowserId = browserId
 
-  return { ok: true, tabId: normalizedTabId, sessionId: session.sessionId }
+  return { ok: true, tabRef, tabId, browserId, sessionId: session.sessionId }
 }
 
 function allowsLeaseFreeForwardMethod(method) {
   return method === 'Target.createTarget'
+}
+
+function resolveBrowserForLeaseFreeForward(state, params = {}) {
+  const requestedBrowserId = sanitizeBrowserId(params.browserId)
+  if (requestedBrowserId) {
+    const client = state.extensionClientsById.get(requestedBrowserId)
+    if (!client || !isSocketOpen(client.socket)) {
+      return { ok: false, error: `Browser ${requestedBrowserId} is not connected on relay port ${state.relayPort}` }
+    }
+    return { ok: true, browserId: requestedBrowserId }
+  }
+
+  const clients = listExtensionClients(state)
+  if (clients.length === 1) {
+    return { ok: true, browserId: clients[0].browserId }
+  }
+  if (clients.length === 0) {
+    return { ok: false, error: 'Relay has no active extension connection' }
+  }
+  return {
+    ok: false,
+    error: `Multiple browsers are connected on relay port ${state.relayPort}. Pass browserId for Target.createTarget.`,
+  }
 }
 
 function resolveSession(state, socket, params = {}, options = {}) {
@@ -462,27 +680,37 @@ function resolveSession(state, socket, params = {}, options = {}) {
     client: typeof params.client === 'string' ? params.client : null,
     createdAt: Date.now(),
     lastSeenAt: Date.now(),
+    leasedTabRef: null,
     leasedTabId: null,
+    leasedBrowserId: null,
   }
   state.sessionsById.set(sessionId, session)
   return { ok: true, session }
 }
 
 function listAttachedTabsWithLease(state) {
-  const attachedTabs = Array.isArray(state.extensionHeartbeatState?.attachedTabs)
-    ? state.extensionHeartbeatState.attachedTabs
+  const tabs = []
+  for (const client of listExtensionClients(state)) {
+    tabs.push(...listAttachedTabsForClient(state, client))
+  }
+  tabs.sort((a, b) => String(a.tabRef).localeCompare(String(b.tabRef)))
+  return tabs
+}
+
+function listAttachedTabsForClient(state, client) {
+  const attachedTabs = Array.isArray(client?.heartbeatState?.attachedTabs)
+    ? client.heartbeatState.attachedTabs
     : []
   const tabs = []
   for (const tab of attachedTabs) {
-    const tabId = parseTabId(tab?.tabId)
-    if (!tabId) continue
+    const decorated = decorateTabMeta(tab, client)
+    if (!decorated?.tabRef) continue
     tabs.push({
-      ...tab,
-      tabId,
-      leasedSessionId: state.tabLeases.get(tabId) || null,
+      ...decorated,
+      leasedSessionId: state.tabLeases.get(decorated.tabRef) || null,
     })
   }
-  tabs.sort((a, b) => a.tabId - b.tabId)
+  tabs.sort((a, b) => String(a.tabRef).localeCompare(String(b.tabRef)))
   return tabs
 }
 
@@ -671,10 +899,6 @@ function handleWebSocketConnection(socket, state) {
       if (entry.role === 'extension') {
         entry.seenAtMs = Date.now()
         state.extensionLastSeenTs = entry.seenAtMs
-        if (state.extensionSocket && state.extensionSocket !== socket && state.extensionSocket.readyState === state.extensionSocket.OPEN) {
-          state.extensionSocket.close(1008, 'new_extension_client')
-        }
-        state.extensionSocket = socket
         startRelayHeartbeatWatchdog(state)
         notifyControllers(state, { method: 'relayEvent', params: { type: 'extension_connected', port: state.relayPort } })
         flushQueuedControllerCommands(state)
@@ -691,15 +915,24 @@ function handleWebSocketConnection(socket, state) {
   })
 
   socket.on('close', () => {
-    const wasExtension = state.extensionSocket === socket
+    const wasExtension = socketMeta.get(socket)?.role === 'extension'
     if (wasExtension) {
-      state.extensionSocket = null
-      state.extensionLastSeenTs = 0
-      state.extensionHeartbeatState = null
-      state.extensionSessionToTab.clear()
-      stopRelayHeartbeatWatchdog(state)
-      notifyControllers(state, { method: 'relayEvent', params: { type: 'extension_disconnected', port: state.relayPort } })
-      failPending(state, 'Relay disconnected')
+      const client = findExtensionClientBySocket(state, socket)
+      if (client) {
+        state.extensionClientsById.delete(client.browserId)
+        failPendingForBrowser(state, client.browserId, 'Relay browser disconnected')
+      }
+      syncLegacyExtensionState(state)
+      if (state.extensionClientsById.size === 0) {
+        stopRelayHeartbeatWatchdog(state)
+        notifyControllers(state, { method: 'relayEvent', params: { type: 'extension_disconnected', port: state.relayPort } })
+        failPending(state, 'Relay disconnected')
+      } else {
+        notifyControllers(state, {
+          method: 'relayEvent',
+          params: { type: 'extension_browser_disconnected', port: state.relayPort, browserId: client?.browserId || null },
+        })
+      }
     } else {
       closeSessionForSocket(state, socket, 'Controller disconnected')
     }
@@ -720,7 +953,17 @@ function onExtensionMessage(msg, socket, state) {
   state.extensionLastSeenTs = now
 
   if (msg && msg.method === 'Grais.extensionHeartbeat') {
-    state.extensionHeartbeatState = {
+    const browser = sanitizeBrowserIdentity(msg.browser)
+    const browserId = browserIdFromIdentity(browser, entry?.browserId || createFallbackBrowserId(state))
+    if (!browserId) return
+    if (entry) entry.browserId = browserId
+
+    const existing = state.extensionClientsById.get(browserId)
+    if (existing && existing.socket !== socket && isSocketOpen(existing.socket)) {
+      existing.socket.close(1008, 'same_browser_reconnected')
+    }
+
+    const heartbeatState = {
       ts: now,
       relayPort: Number.isFinite(Number(msg.relayPort)) ? Number(msg.relayPort) : state.relayPort,
       activeTab: cleanTabMeta(msg.activeTab),
@@ -732,16 +975,30 @@ function onExtensionMessage(msg, socket, state) {
       allowTargetCreate: typeof msg.allowTargetCreate === 'boolean' ? msg.allowTargetCreate : null,
       extensionVersion: typeof msg.extensionVersion === 'string' ? msg.extensionVersion : null,
       extensionName: typeof msg.extensionName === 'string' ? msg.extensionName : null,
-      browser: sanitizeBrowserIdentity(msg.browser),
+      browser,
       extensionCapabilities:
         msg.extensionCapabilities && typeof msg.extensionCapabilities === 'object' ? msg.extensionCapabilities : null,
     }
-    refreshExtensionSessionMap(state)
+    const client = {
+      browserId,
+      socket,
+      browser,
+      lastSeenTs: now,
+      heartbeatState,
+      extensionSessionToTab: existing?.socket === socket && existing.extensionSessionToTab instanceof Map
+        ? existing.extensionSessionToTab
+        : new Map(),
+    }
+    state.extensionClientsById.set(browserId, client)
+    syncLegacyExtensionState(state)
+    refreshExtensionSessionMap(state, client)
+    flushQueuedControllerCommands(state)
     return
   }
 
   if (msg && typeof msg.id === 'number') {
-    console.log('[Relay] extension response', { relayId: msg.id, port: state.relayPort })
+    const client = findExtensionClientBySocket(state, socket)
+    console.log('[Relay] extension response', { relayId: msg.id, port: state.relayPort, browserId: client?.browserId || null })
     const pending = state.pendingByRelayId.get(msg.id)
     if (!pending) return
 
@@ -760,7 +1017,10 @@ function onExtensionMessage(msg, socket, state) {
         })
         return
       }
-      const lease = claimTabLease(state, session, msg.result.tabId, true)
+      const lease = claimTabLease(state, session, {
+        tabId: msg.result.tabId,
+        browserId: pending.browserId || client?.browserId || null,
+      }, true)
       if (!lease.ok) {
         clearTimeout(pending.timer)
         pendingByRelayIdDelete(state, msg.id)
@@ -772,6 +1032,8 @@ function onExtensionMessage(msg, socket, state) {
       }
       if (msg.result && typeof msg.result === 'object' && !Array.isArray(msg.result)) {
         msg.result.leasedTabId = msg.result.tabId
+        msg.result.leasedTabRef = lease.tabRef
+        msg.result.browserId = lease.browserId
         msg.result.relaySessionId = pending.relaySessionId
       }
     }
@@ -789,8 +1051,9 @@ function onExtensionMessage(msg, socket, state) {
   }
 
   if (msg && msg.method === 'forwardCDPEvent') {
-    updateExtensionSessionMapFromEvent(state, msg)
-    routeExtensionEventToControllers(state, msg)
+    const client = findExtensionClientBySocket(state, socket)
+    updateExtensionSessionMapFromEvent(state, msg, client)
+    routeExtensionEventToControllers(state, msg, client)
     return
   }
 
@@ -841,7 +1104,7 @@ function onControllerMessage(msg, socket, state) {
     return
   }
 
-  if (!state.extensionSocket || state.extensionSocket.readyState !== state.extensionSocket.OPEN) {
+  if (!hasActiveExtensionForForward(state, binding.forward)) {
     queueControllerCommand(state, binding.forward, socket)
     return
   }
@@ -863,9 +1126,8 @@ function handleControllerRelayMethod(msg, socket, state) {
     if (!resolved.ok) return { handled: true, ok: false, error: resolved.error }
     const session = resolved.session
     session.lastSeenAt = Date.now()
-    const requestedTabId = parseTabId(params.tabId)
-    if (requestedTabId) {
-      const lease = claimTabLease(state, session, requestedTabId, params.force === true)
+    if (params.tabRef || params.browserId || params.tabId) {
+      const lease = claimTabLease(state, session, params, params.force === true)
       if (!lease.ok) return { handled: true, ok: false, error: lease.error }
     }
     return {
@@ -874,7 +1136,9 @@ function handleControllerRelayMethod(msg, socket, state) {
       result: {
         ok: true,
         sessionId: session.sessionId,
+        tabRef: session.leasedTabRef || null,
         tabId: Number.isInteger(session.leasedTabId) ? session.leasedTabId : null,
+        browserId: session.leasedBrowserId || null,
         relayPort: state.relayPort,
       },
     }
@@ -893,7 +1157,7 @@ function handleControllerRelayMethod(msg, socket, state) {
     if (!resolved.ok) return { handled: true, ok: false, error: resolved.error }
     const session = resolved.session
     session.lastSeenAt = Date.now()
-    const lease = claimTabLease(state, session, params.tabId, params.force === true)
+    const lease = claimTabLease(state, session, params, params.force === true)
     if (!lease.ok) return { handled: true, ok: false, error: lease.error }
     return {
       handled: true,
@@ -901,7 +1165,9 @@ function handleControllerRelayMethod(msg, socket, state) {
       result: {
         ok: true,
         sessionId: session.sessionId,
+        tabRef: session.leasedTabRef,
         tabId: session.leasedTabId,
+        browserId: session.leasedBrowserId,
       },
     }
   }
@@ -910,15 +1176,18 @@ function handleControllerRelayMethod(msg, socket, state) {
     const resolved = resolveSession(state, socket, params, { createIfMissing: false })
     if (!resolved.ok) return { handled: true, ok: false, error: resolved.error }
     const session = resolved.session
-    const requestedTabId = parseTabId(params.tabId)
-    if (requestedTabId && session.leasedTabId !== requestedTabId) {
+    const requested = params.tabRef || params.browserId || params.tabId ? resolveTabReference(state, params) : null
+    if (requested && !requested.ok) return { handled: true, ok: false, error: requested.error }
+    if (requested?.tabRef && session.leasedTabRef !== requested.tabRef) {
       return {
         handled: true,
         ok: false,
-        error: `Session ${session.sessionId} does not currently lease tab ${requestedTabId}`,
+        error: `Session ${session.sessionId} does not currently lease tab ${requested.tabRef}`,
       }
     }
     const releasedTabId = session.leasedTabId
+    const releasedTabRef = session.leasedTabRef
+    const releasedBrowserId = session.leasedBrowserId
     releaseSessionTabLease(state, session)
     return {
       handled: true,
@@ -926,7 +1195,9 @@ function handleControllerRelayMethod(msg, socket, state) {
       result: {
         ok: true,
         sessionId: session.sessionId,
+        tabRef: releasedTabRef || null,
         tabId: Number.isInteger(releasedTabId) ? releasedTabId : null,
+        browserId: releasedBrowserId || null,
       },
     }
   }
@@ -941,7 +1212,9 @@ function handleControllerRelayMethod(msg, socket, state) {
       result: {
         ok: true,
         sessionId: session.sessionId,
+        tabRef: session.leasedTabRef || null,
         tabId: Number.isInteger(session.leasedTabId) ? session.leasedTabId : null,
+        browserId: session.leasedBrowserId || null,
         createdAt: session.createdAt,
         lastSeenAt: session.lastSeenAt,
       },
@@ -992,15 +1265,29 @@ function bindForwardCommandToSessionLease(state, socket, forward) {
   }
   session.lastSeenAt = Date.now()
 
-  let targetTabId = parseTabId(payloadParams.tabId)
-  if (targetTabId) {
-    const lease = claimTabLease(state, session, targetTabId, false)
+  let targetTabRef = parseTabRef(payloadParams.tabRef)
+  let targetTabId = targetTabRef?.tabId || parseTabId(payloadParams.tabId)
+  let targetBrowserId = targetTabRef?.browserId || sanitizeBrowserId(payloadParams.browserId)
+  if (targetTabRef || targetBrowserId || targetTabId) {
+    const lease = claimTabLease(state, session, {
+      tabRef: targetTabRef?.tabRef || payloadParams.tabRef,
+      browserId: targetBrowserId,
+      tabId: targetTabId,
+    }, false)
     if (!lease.ok) {
       return { ok: false, error: lease.error }
     }
-  } else if (Number.isInteger(session.leasedTabId)) {
+    targetTabRef = parseTabRef(lease.tabRef)
+    targetTabId = lease.tabId
+    targetBrowserId = lease.browserId
+  } else if (session.leasedTabRef && Number.isInteger(session.leasedTabId)) {
+    targetTabRef = parseTabRef(session.leasedTabRef)
     targetTabId = session.leasedTabId
+    targetBrowserId = session.leasedBrowserId
   } else if (allowsLeaseFreeForwardMethod(forwardMethod)) {
+    const browser = resolveBrowserForLeaseFreeForward(state, payloadParams)
+    if (!browser.ok) return { ok: false, error: browser.error }
+    payloadParams.browserId = browser.browserId
     return { ok: true, forward }
   } else {
     return {
@@ -1010,6 +1297,8 @@ function bindForwardCommandToSessionLease(state, socket, forward) {
   }
 
   payloadParams.tabId = targetTabId
+  payloadParams.tabRef = targetTabRef?.tabRef || createTabRef(targetBrowserId, targetTabId)
+  payloadParams.browserId = targetBrowserId
   if (typeof payloadParams.method === 'string') {
     const methodParams = typeof payloadParams.params === 'object' && payloadParams.params !== null
       ? payloadParams.params
@@ -1027,71 +1316,75 @@ function bindForwardCommandToSessionLease(state, socket, forward) {
   return { ok: true, forward }
 }
 
-function refreshExtensionSessionMap(state) {
-  state.extensionSessionToTab.clear()
-  const attachedTabs = Array.isArray(state.extensionHeartbeatState?.attachedTabs)
-    ? state.extensionHeartbeatState.attachedTabs
+function refreshExtensionSessionMap(_state, client) {
+  if (!client) return
+  client.extensionSessionToTab.clear()
+  const attachedTabs = Array.isArray(client.heartbeatState?.attachedTabs)
+    ? client.heartbeatState.attachedTabs
     : []
   for (const attached of attachedTabs) {
     const tabId = parseTabId(attached?.tabId)
     const sessionId = typeof attached?.sessionId === 'string' ? attached.sessionId.trim() : ''
     if (tabId && sessionId) {
-      state.extensionSessionToTab.set(sessionId, tabId)
+      client.extensionSessionToTab.set(sessionId, createTabRef(client.browserId, tabId))
     }
   }
 }
 
-function updateExtensionSessionMapFromEvent(state, message) {
+function updateExtensionSessionMapFromEvent(state, message, client) {
   if (!message || message.method !== 'forwardCDPEvent') return
+  if (!client) client = getPrimaryExtensionClient(state)
+  if (!client) return
   const payload = message.params
   const tabId = parseTabId(payload?.tabId)
   const topSessionId = typeof payload?.sessionId === 'string' ? payload.sessionId.trim() : ''
   if (tabId && topSessionId) {
-    state.extensionSessionToTab.set(topSessionId, tabId)
+    client.extensionSessionToTab.set(topSessionId, createTabRef(client.browserId, tabId))
   }
 
   if (payload?.method === 'Target.attachedToTarget') {
     const nestedSessionId = typeof payload?.params?.sessionId === 'string' ? payload.params.sessionId.trim() : ''
     if (tabId && nestedSessionId) {
-      state.extensionSessionToTab.set(nestedSessionId, tabId)
+      client.extensionSessionToTab.set(nestedSessionId, createTabRef(client.browserId, tabId))
     }
   } else if (payload?.method === 'Target.detachedFromTarget') {
     const nestedSessionId = typeof payload?.params?.sessionId === 'string' ? payload.params.sessionId.trim() : ''
     if (nestedSessionId) {
-      state.extensionSessionToTab.delete(nestedSessionId)
+      client.extensionSessionToTab.delete(nestedSessionId)
     }
   }
 }
 
-function resolveEventTabId(state, message) {
+function resolveEventTabRef(state, message, client) {
+  if (!client) client = getPrimaryExtensionClient(state)
   const explicitTabId = parseTabId(message?.params?.tabId)
-  if (explicitTabId) return explicitTabId
+  if (explicitTabId && client) return createTabRef(client.browserId, explicitTabId)
 
   const topSessionId = typeof message?.params?.sessionId === 'string' ? message.params.sessionId.trim() : ''
   if (topSessionId) {
-    const mapped = state.extensionSessionToTab.get(topSessionId)
-    if (Number.isInteger(mapped)) return mapped
+    const mapped = client?.extensionSessionToTab?.get(topSessionId)
+    if (mapped) return mapped
   }
 
   const nestedSessionId = typeof message?.params?.params?.sessionId === 'string'
     ? message.params.params.sessionId.trim()
     : ''
   if (nestedSessionId) {
-    const mapped = state.extensionSessionToTab.get(nestedSessionId)
-    if (Number.isInteger(mapped)) return mapped
+    const mapped = client?.extensionSessionToTab?.get(nestedSessionId)
+    if (mapped) return mapped
   }
 
   return null
 }
 
-function routeExtensionEventToControllers(state, message) {
-  const eventTabId = resolveEventTabId(state, message)
-  if (!eventTabId) {
+function routeExtensionEventToControllers(state, message, client) {
+  const eventTabRef = resolveEventTabRef(state, message, client)
+  if (!eventTabRef) {
     sendEventToSingleControllerIfSafe(state, message)
     return
   }
 
-  const leasedSessionId = state.tabLeases.get(eventTabId)
+  const leasedSessionId = state.tabLeases.get(eventTabRef)
   if (!leasedSessionId) {
     sendEventToSingleControllerIfSafe(state, message)
     return
@@ -1105,10 +1398,32 @@ function routeExtensionEventToControllers(state, message) {
   safeSend(session.socket, message)
 }
 
+function selectExtensionClientForForward(state, forward) {
+  const params = typeof forward?.params === 'object' && forward.params !== null ? forward.params : {}
+  const requestedBrowserId = sanitizeBrowserId(params.browserId)
+  if (requestedBrowserId) {
+    const client = state.extensionClientsById.get(requestedBrowserId)
+    return client && isSocketOpen(client.socket) ? client : null
+  }
+
+  const tabRef = parseTabRef(params.tabRef)
+  if (tabRef) {
+    const client = state.extensionClientsById.get(tabRef.browserId)
+    return client && isSocketOpen(client.socket) ? client : null
+  }
+
+  const clients = listExtensionClients(state)
+  return clients.length === 1 ? clients[0] : null
+}
+
+function hasActiveExtensionForForward(state, forward) {
+  return Boolean(selectExtensionClientForForward(state, forward))
+}
+
 function sendEventToSingleControllerIfSafe(state, message) {
   const controllers = []
   for (const controller of state.controllerSockets) {
-    if (controller === state.extensionSocket) continue
+    if (socketMeta.get(controller)?.role === 'extension') continue
     if (controller.readyState !== controller.OPEN) continue
     controllers.push(controller)
   }
@@ -1138,6 +1453,7 @@ function queueControllerCommand(state, forward, socket) {
     relayId,
     socket,
     requestId: forward.id,
+    forward,
     payload,
     timer: setTimeout(() => {
       dequeueControllerCommand(state, relayId, `Relay has no active extension connection for ${QUEUED_REQUEST_TIMEOUT_MS}ms`)
@@ -1150,6 +1466,7 @@ function queueControllerCommand(state, forward, socket) {
     requestId: forward.id,
     forwardMethod: typeof forward?.params?.method === 'string' ? forward.params.method : null,
     relaySessionId: parseRelaySessionId(forward?.params?.relaySessionId),
+    browserId: sanitizeBrowserId(forward?.params?.browserId),
     timer: queueEntry.timer,
   })
 
@@ -1194,11 +1511,16 @@ function clearQueuedCommandsForSocket(state, socket, reason = 'Controller discon
 }
 
 function flushQueuedControllerCommands(state) {
-  if (!state.extensionSocket || state.extensionSocket.readyState !== state.extensionSocket.OPEN) return
+  if (listExtensionClients(state).length === 0) return
 
+  const deferred = []
   while (state.queuedControllerRequests.length > 0) {
     const entry = state.queuedControllerRequests.shift()
     if (!entry) return
+    if (!hasActiveExtensionForForward(state, entry.forward || entry.payload)) {
+      deferred.push(entry)
+      continue
+    }
     const pending = state.pendingByRelayId.get(entry.relayId)
     if (!pending) {
       clearTimeout(entry.timer)
@@ -1233,6 +1555,7 @@ function flushQueuedControllerCommands(state) {
       )
     }
   }
+  state.queuedControllerRequests.push(...deferred)
 }
 
 function forwardControllerToExtension(state, forward, socket) {
@@ -1243,6 +1566,7 @@ function forwardControllerToExtension(state, forward, socket) {
     requestId: forward.id,
     method: forward.method,
     port: state.relayPort,
+    browserId: sanitizeBrowserId(forward?.params?.browserId),
   })
   const payload = {
     id: relayId,
@@ -1255,6 +1579,7 @@ function forwardControllerToExtension(state, forward, socket) {
     requestId: forward.id,
     forwardMethod: typeof forward?.params?.method === 'string' ? forward.params.method : null,
     relaySessionId: parseRelaySessionId(forward?.params?.relaySessionId),
+    browserId: sanitizeBrowserId(forward?.params?.browserId),
     timer: setTimeout(() => {
       pendingByRelayIdDelete(state, relayId)
       throwErrorToController(socket, forward.id, `Relay timed out after ${requestTimeoutMs}ms`)
@@ -1268,7 +1593,7 @@ function forwardControllerToExtension(state, forward, socket) {
   } catch (error) {
     clearTimeout(pending.timer)
     pendingByRelayIdDelete(state, relayId)
-    if (!state.extensionSocket || state.extensionSocket.readyState !== state.extensionSocket.OPEN) {
+    if (!hasActiveExtensionForForward(state, forward)) {
       queueControllerCommand(state, forward, socket)
       return
     }
@@ -1281,7 +1606,8 @@ function forwardControllerToExtension(state, forward, socket) {
 }
 
 function sendToExtension(state, payload) {
-  if (!state.extensionSocket || state.extensionSocket.readyState !== state.extensionSocket.OPEN) {
+  const client = selectExtensionClientForForward(state, payload)
+  if (!client || !isSocketOpen(client.socket)) {
     throw new Error('Relay has no active extension connection')
   }
   console.log('[Relay] sendToExtension', {
@@ -1289,8 +1615,9 @@ function sendToExtension(state, payload) {
     method: payload?.method,
     hasParams: Boolean(payload?.params),
     port: state.relayPort,
+    browserId: client.browserId,
   })
-  state.extensionSocket.send(JSON.stringify(payload))
+  client.socket.send(JSON.stringify(payload))
 }
 
 function failPending(state, reason, socket) {
@@ -1302,6 +1629,24 @@ function failPending(state, reason, socket) {
     clearTimeout(pending.timer)
     state.pendingByRelayId.delete(relayId)
     throwErrorToController(pending.socket, pending.requestId, reason)
+  }
+}
+
+function failPendingForBrowser(state, browserId, reason) {
+  const targetBrowserId = sanitizeBrowserId(browserId)
+  if (!targetBrowserId) return
+  for (const [relayId, pending] of state.pendingByRelayId.entries()) {
+    if (pending.browserId !== targetBrowserId) continue
+    clearTimeout(pending.timer)
+    state.pendingByRelayId.delete(relayId)
+    throwErrorToController(pending.socket, pending.requestId, reason)
+  }
+  for (let index = state.queuedControllerRequests.length - 1; index >= 0; index -= 1) {
+    const entry = state.queuedControllerRequests[index]
+    const entryBrowserId = sanitizeBrowserId(entry?.forward?.params?.browserId || entry?.payload?.params?.browserId)
+    if (entryBrowserId !== targetBrowserId) continue
+    state.queuedControllerRequests.splice(index, 1)
+    clearTimeout(entry.timer)
   }
 }
 
@@ -1338,7 +1683,7 @@ function isExtensionMessage(msg) {
 
 function notifyControllers(state, message) {
   for (const controller of state.controllerSockets) {
-    if (controller !== state.extensionSocket) {
+    if (socketMeta.get(controller)?.role !== 'extension') {
       safeSend(controller, message)
     }
   }
@@ -1361,11 +1706,12 @@ function safeSend(socket, payload) {
 function startRelayHeartbeatWatchdog(state) {
   if (state.relayHeartbeatWatchdog) return
   state.relayHeartbeatWatchdog = setInterval(() => {
-    if (!state.extensionSocket || state.extensionSocket.readyState !== state.extensionSocket.OPEN) return
-    if (!state.extensionLastSeenTs) return
-    const elapsed = Date.now() - state.extensionLastSeenTs
-    if (elapsed > RELAY_HEARTBEAT_TIMEOUT_MS) {
-      state.extensionSocket.close(1001, 'heartbeat timeout')
+    for (const client of listExtensionClients(state)) {
+      if (!client.lastSeenTs) continue
+      const elapsed = Date.now() - client.lastSeenTs
+      if (elapsed > RELAY_HEARTBEAT_TIMEOUT_MS) {
+        client.socket.close(1001, 'heartbeat timeout')
+      }
     }
   }, RELAY_HEARTBEAT_INTERVAL_MS)
 }
@@ -1390,11 +1736,13 @@ function shutdown(exitCode = 0, message) {
 
   for (const state of portStates.values()) {
     failPending(state, 'Relay shutting down')
-    if (state.extensionSocket && state.extensionSocket.readyState === state.extensionSocket.OPEN) {
-      state.extensionSocket.close(1001, 'relay shutdown')
+    for (const client of state.extensionClientsById.values()) {
+      if (isSocketOpen(client.socket)) {
+        client.socket.close(1001, 'relay shutdown')
+      }
     }
     for (const controller of state.controllerSockets) {
-      if (controller !== state.extensionSocket) {
+      if (socketMeta.get(controller)?.role !== 'extension') {
         controller.close(1001, 'relay shutdown')
       }
     }

--- a/scripts/extension-status.js
+++ b/scripts/extension-status.js
@@ -61,6 +61,7 @@ async function main() {
     extensionVersion: status.extensionVersion,
     extensionName: status.extensionName,
     browser: status.browser,
+    browsers: status.browsers,
     primaryExtensionPath: installBundle.path,
     primaryPathKind: installBundle.pathKind,
     visibleExtensionPath: installBundle.visiblePath,
@@ -146,6 +147,13 @@ async function getExtensionConnectionStatus() {
       extensionVersion: typeof targetPort?.extensionVersion === 'string' ? targetPort.extensionVersion : null,
       extensionName: typeof targetPort?.extensionName === 'string' ? targetPort.extensionName : null,
       browser: sanitizeBrowserIdentity(targetPort?.browser),
+      browsers: Array.isArray(targetPort?.browsers)
+        ? targetPort.browsers.map((entry) => ({
+            browserId: typeof entry?.browserId === 'string' ? entry.browserId : null,
+            browser: sanitizeBrowserIdentity(entry?.browser),
+            attachedTabCount: Number.isFinite(Number(entry?.attachedTabCount)) ? Number(entry.attachedTabCount) : 0,
+          })).filter((entry) => entry.browserId || entry.browser)
+        : [],
       error: null,
     }
   } catch (error) {
@@ -158,13 +166,14 @@ async function getExtensionConnectionStatus() {
       extensionVersion: null,
       extensionName: null,
       browser: null,
+      browsers: [],
       error: `Relay is not reachable at ${relayStatusUrl}: ${error instanceof Error ? error.message : String(error)}`,
     }
   }
 }
 
 function printSummary(payload) {
-  console.log('Primary Chrome extension path:')
+  console.log('Primary extension path:')
   console.log(`  ${payload.primaryExtensionPath}`)
   console.log(`Primary path source: ${describePrimaryPath(payload.primaryPathKind)}`)
   console.log(`Relay status URL: ${payload.relayStatusUrl}`)
@@ -178,11 +187,18 @@ function printSummary(payload) {
 
   if (payload.extensionConnected) {
     const browserLabel = formatBrowserIdentity(payload.browser)
-    console.log(
-      browserLabel
-        ? `Relay status: extension connected on port ${payload.port} via ${browserLabel}`
-        : `Relay status: Chrome extension connected on port ${payload.port}`,
-    )
+    const browsers = Array.isArray(payload.browsers) ? payload.browsers : []
+    let statusLine = `Relay status: extension connected on port ${payload.port}`
+    if (browsers.length > 1) {
+      statusLine = `Relay status: ${browsers.length} browser extensions connected on port ${payload.port}`
+    } else if (browserLabel) {
+      statusLine = `Relay status: extension connected on port ${payload.port} via ${browserLabel}`
+    }
+    console.log(statusLine)
+    for (const entry of browsers) {
+      const label = formatBrowserIdentity(entry.browser) || entry.browserId || 'unknown browser'
+      console.log(`Connected browser: ${label} (${entry.attachedTabCount} attached tab${entry.attachedTabCount === 1 ? '' : 's'})`)
+    }
     if (payload.extensionLastSeenAgoMs !== null) {
       console.log(`Last heartbeat: ${payload.extensionLastSeenAgoMs}ms ago`)
     }
@@ -195,12 +211,12 @@ function printSummary(payload) {
     return
   }
 
-  console.log(`Relay status: Chrome extension is not connected on port ${payload.port}`)
+  console.log(`Relay status: browser extension is not connected on port ${payload.port}`)
   if (payload.extensionPorts.length > 0) {
     console.log(`Extension is currently connected on other relay port(s): ${payload.extensionPorts.join(', ')}`)
   }
-  console.log('This means Chrome has not confirmed the extension in the current browser profile yet, or the popup has not been opened since relay startup.')
-  console.log('Open Chrome, verify Agent Browser Relay is enabled, then open the toolbar popup once.')
+  console.log('This means the browser has not confirmed the extension in the current profile yet, or the popup has not been opened since relay startup.')
+  console.log('Open the browser, verify Agent Browser Relay is enabled, then open the toolbar popup once.')
   console.log('The popup now wakes the extension and should show a relay-connected status when the load is confirmed.')
   console.log('If this is first run and the extension is missing from Chrome, load unpacked from the primary path above.')
   console.log('Re-run this command, or use `npm run extension:status -- --wait-for-connected --connected-timeout-ms 120000`.')

--- a/scripts/read-active-tab.js
+++ b/scripts/read-active-tab.js
@@ -24,6 +24,8 @@ const SKILL_CAPABILITIES = Object.freeze({
     '--expression-stdin',
     '--preset',
     '--tab-id',
+    '--tab-ref',
+    '--browser-id',
     '--wait-for-attach',
   ],
   relayMethods: [
@@ -142,7 +144,11 @@ const screenshotTimeoutMs = parsePositiveInt(
   'screenshot-timeout-ms',
 )
 const preset = String(options.preset || DEFAULT_PRESET).trim().toLowerCase()
-const requestedTabId = parseOptionalTabId(options.tabId || process.env.GRAIS_TAB_ID, 'tab-id')
+const requestedTabRef = parseOptionalTabRef(options.tabRef || process.env.GRAIS_TAB_REF)
+const requestedBrowserId = parseOptionalBrowserId(options.browserId || process.env.GRAIS_BROWSER_ID)
+const requestedTabId = parseOptionalTabId(options.tabId || process.env.GRAIS_TAB_ID, 'tab-id') || requestedTabRef?.tabId || null
+const requestedTabRefValue = requestedTabRef?.tabRef || (requestedBrowserId && Number.isInteger(requestedTabId) ? `${requestedBrowserId}:${requestedTabId}` : null)
+const hasRequestedTabTarget = Boolean(requestedTabRefValue || Number.isInteger(requestedTabId))
 
 const textRegex = parseRegexOption('text-regex', options.textRegex, options.textRegexFlags)
 const excludeTextRegex = parseRegexOption('exclude-text-regex', options.excludeTextRegex, options.excludeTextRegexFlags)
@@ -174,6 +180,8 @@ let socketOpenedOnce = false
 let rejectAllPending
 let relaySessionId = null
 let leasedTabId = Number.isInteger(requestedTabId) ? requestedTabId : null
+let leasedTabRef = requestedTabRefValue
+let leasedBrowserId = requestedTabRef?.browserId || requestedBrowserId || null
 let relayStatusSnapshot = null
 let cachedExpression = null
 
@@ -191,7 +199,9 @@ function getRelaySource() {
     relayStatusUrl,
     relayWebSocketUrl,
     relaySessionId,
+    tabRef: leasedTabRef || null,
     tabId: Number.isInteger(leasedTabId) ? leasedTabId : null,
+    browserId: leasedBrowserId || null,
     capabilities: SKILL_CAPABILITIES,
     browser: observedBrowser,
     extension: {
@@ -311,6 +321,8 @@ function parseArgs(argv) {
     else if (arg === '--expression-stdin') out.expressionStdin = true
     else if (arg === '--preset' && argv[i + 1]) out.preset = argv[++i]
     else if (arg === '--tab-id' && argv[i + 1]) out.tabId = argv[++i]
+    else if (arg === '--tab-ref' && argv[i + 1]) out.tabRef = argv[++i]
+    else if (arg === '--browser-id' && argv[i + 1]) out.browserId = argv[++i]
     else if (arg === '--pretty' && argv[i + 1]) out.pretty = argv[++i] !== 'false'
     else if (arg === '--wait-for-attach') out.waitForAttach = true
     else if (arg === '--require-target-create') out.requireTargetCreate = true
@@ -492,6 +504,29 @@ function parseOptionalTabId(value, label = 'tab-id') {
     throw new Error(`Invalid ${label}: ${String(value)} (must be positive integer)`)
   }
   return parsed
+}
+
+function parseOptionalBrowserId(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return null
+  const normalized = String(value).trim().replace(/[^a-zA-Z0-9_.-]/g, '_')
+  if (!normalized) throw new Error(`Invalid browser-id: ${String(value)}`)
+  return normalized
+}
+
+function parseOptionalTabRef(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return null
+  const raw = String(value).trim()
+  const splitAt = raw.lastIndexOf(':')
+  if (splitAt <= 0 || splitAt === raw.length - 1) {
+    throw new Error(`Invalid tab-ref: ${raw} (expected browserId:tabId)`)
+  }
+  const browserId = parseOptionalBrowserId(raw.slice(0, splitAt))
+  const tabId = parseOptionalTabId(raw.slice(splitAt + 1), 'tab-ref tab id')
+  return {
+    browserId,
+    tabId,
+    tabRef: `${browserId}:${tabId}`,
+  }
 }
 
 function parseRegexOption(label, pattern, flags) {
@@ -1412,46 +1447,73 @@ function sendRelayCommand(method, params, timeout = timeoutMs) {
   if (Number.isInteger(leasedTabId)) {
     relayParams.tabId = leasedTabId
   }
+  if (leasedTabRef) {
+    relayParams.tabRef = leasedTabRef
+  }
+  if (leasedBrowserId) {
+    relayParams.browserId = leasedBrowserId
+  }
   return sendRelayRequest('forwardCDPCommand', relayParams, timeout)
+}
+
+function requestedRelayTargetParams() {
+  return {
+    ...(requestedTabRefValue ? { tabRef: requestedTabRefValue } : {}),
+    ...(requestedBrowserId ? { browserId: requestedBrowserId } : {}),
+    ...(Number.isInteger(requestedTabId) ? { tabId: requestedTabId } : {}),
+  }
+}
+
+function rememberLease(result) {
+  if (!result || typeof result !== 'object') return
+  if (typeof result.tabRef === 'string' && result.tabRef.trim()) {
+    leasedTabRef = result.tabRef.trim()
+  }
+  if (typeof result.browserId === 'string' && result.browserId.trim()) {
+    leasedBrowserId = result.browserId.trim()
+  } else if (leasedTabRef) {
+    const parsed = parseOptionalTabRef(leasedTabRef)
+    leasedBrowserId = parsed?.browserId || leasedBrowserId
+  }
+  if (Number.isInteger(result.tabId)) {
+    leasedTabId = result.tabId
+  }
 }
 
 async function ensureRelaySession() {
   if (relaySessionId) return relaySessionId
   const openResult = await sendRelayRequest('Grais.relay.openSession', {
     client: 'read-active-tab',
-    ...(Number.isInteger(requestedTabId) ? { tabId: requestedTabId } : {}),
+    ...requestedRelayTargetParams(),
   })
   if (!openResult || openResult.ok === false || typeof openResult.sessionId !== 'string') {
     throw new Error(openResult?.error || 'Failed to open relay session')
   }
   relaySessionId = openResult.sessionId
-  if (Number.isInteger(openResult.tabId)) {
-    leasedTabId = openResult.tabId
-  }
+  rememberLease(openResult)
   return relaySessionId
 }
 
-async function ensureRelayTabLease(tabId) {
-  const requested = parseOptionalTabId(tabId, 'tab-id')
-  if (!requested) return null
+async function ensureRelayTargetLease() {
+  if (!hasRequestedTabTarget) return null
   await ensureRelaySession()
   const claimResult = await sendRelayRequest('Grais.relay.claimTab', {
     sessionId: relaySessionId,
-    tabId: requested,
+    ...requestedRelayTargetParams(),
   })
   if (!claimResult || claimResult.ok === false) {
-    throw new Error(claimResult?.error || `Failed to claim tab lease for tab ${requested}`)
+    throw new Error(claimResult?.error || 'Failed to claim tab lease')
   }
-  leasedTabId = requested
-  return requested
+  rememberLease(claimResult)
+  return leasedTabRef || leasedTabId
 }
 
 async function prepareTargetTabForCommand() {
-  if (Number.isInteger(requestedTabId)) {
-    await ensureRelayTabLease(requestedTabId)
+  if (hasRequestedTabTarget) {
+    await ensureRelayTargetLease()
     const attachResult = await sendRelayCommand('Grais.debugger.attachTab', { tabId: requestedTabId })
     if (attachResult && attachResult.ok === false) {
-      throw new Error(attachResult.error || `Failed to attach tab ${requestedTabId}`)
+      throw new Error(attachResult.error || `Failed to attach tab ${leasedTabRef || requestedTabId}`)
     }
     return
   }
@@ -1580,6 +1642,9 @@ function sanitizeStatusTab(value) {
   if (!value || typeof value !== 'object') return null
   return {
     tabId: Number.isInteger(value.tabId) ? value.tabId : null,
+    tabRef: typeof value.tabRef === 'string' ? value.tabRef : null,
+    browserId: typeof value.browserId === 'string' ? value.browserId : null,
+    browser: sanitizeBrowserIdentity(value.browser),
     url: typeof value.url === 'string' ? value.url : null,
     title: typeof value.title === 'string' ? value.title : null,
     windowId: Number.isInteger(value.windowId) ? value.windowId : null,
@@ -1593,6 +1658,8 @@ function sanitizeStatusLease(value) {
   if (!value || typeof value !== 'object') return null
   return {
     tabId: Number.isInteger(value.tabId) ? value.tabId : null,
+    tabRef: typeof value.tabRef === 'string' ? value.tabRef : null,
+    browserId: typeof value.browserId === 'string' ? value.browserId : null,
     sessionId: typeof value.sessionId === 'string' ? value.sessionId : null,
   }
 }
@@ -1691,6 +1758,7 @@ function findAttachedTabAcrossPorts(snapshot, tabId) {
 function describeStatusTab(tab) {
   if (!tab) return 'unknown tab'
   const parts = []
+  if (tab.tabRef) parts.push(`[${tab.tabRef}]`)
   if (tab.title) parts.push(tab.title)
   if (tab.url) parts.push(tab.url)
   if (parts.length === 0) return `tab ${tab.tabId || 'unknown'}`
@@ -2013,8 +2081,8 @@ async function ensureMetadataReadyForCommand() {
     throw createReadinessErrorFromState(buildBlockedCheckResult(relay, extension, requestedTabBlocker))
   }
 
-  if (Number.isInteger(requestedTabId)) {
-    await ensureRelayTabLease(requestedTabId)
+  if (hasRequestedTabTarget) {
+    await ensureRelayTargetLease()
   }
 }
 
@@ -2121,7 +2189,7 @@ async function checkBridge() {
     connected: false,
     error: null,
   }
-  const allowTablessTargetCreateCheck = requireTargetCreate && !Number.isInteger(requestedTabId)
+  const allowTablessTargetCreateCheck = requireTargetCreate && !hasRequestedTabTarget
   let snapshot = null
 
   try {
@@ -2193,11 +2261,11 @@ async function checkBridge() {
     }
 
     try {
-      if (Number.isInteger(requestedTabId)) {
-        await ensureRelayTabLease(requestedTabId)
+      if (hasRequestedTabTarget) {
+        await ensureRelayTargetLease()
         const attachResult = await sendRelayCommand('Grais.debugger.attachTab', { tabId: requestedTabId })
         if (attachResult && attachResult.ok === false) {
-          throw new Error(attachResult.error || `Tab ${requestedTabId} attachment is not ready`)
+          throw new Error(attachResult.error || `Tab ${leasedTabRef || requestedTabId} attachment is not ready`)
         }
       } else {
         const attachResult = await sendRelayCommand('Grais.debugger.ensureActiveTab')
@@ -2214,13 +2282,13 @@ async function checkBridge() {
       if (!pingResult) {
         throw new Error(
           Number.isInteger(requestedTabId)
-            ? `No response from tab ${requestedTabId} through relay bridge`
+            ? `No response from tab ${leasedTabRef || requestedTabId} through relay bridge`
             : 'No response from relay bridge',
         )
       }
       extension.connected = true
     } catch (ensureError) {
-      if (!Number.isInteger(requestedTabId)) {
+      if (!hasRequestedTabTarget) {
         const pingResult = await sendRelayCommand('Runtime.evaluate', {
           expression: '1 + 1',
           returnByValue: true,
@@ -2414,7 +2482,7 @@ async function main() {
     }
 
     if (checkOnly) {
-      if (waitForAttach && attachTimeoutMs > 0 && !(requireTargetCreate && !Number.isInteger(requestedTabId))) {
+      if (waitForAttach && attachTimeoutMs > 0 && !(requireTargetCreate && !hasRequestedTabTarget)) {
         await waitForAttachmentReady({ timeoutMs: attachTimeoutMs, pollMs: attachPollMs })
       }
       const status = await checkBridge()
@@ -2548,6 +2616,8 @@ function printUsage() {
   console.log(`Usage:
   node read-active-tab.js [--host 127.0.0.1] [--port 18793] [--selector "body"] [--preset "default|whatsapp|whatsapp-messages|wa|chat-audit|chat"]
     [--tab-id 123]
+    [--tab-ref browserId:123]
+    [--browser-id browserId]
     [--wait-for-attach] [--attach-timeout-ms 120000] [--attach-poll-ms 500]
     [--require-target-create]
     [--status-timeout-ms 1200]
@@ -2566,7 +2636,9 @@ function printUsage() {
 
   --check: performs relay + extension handshake check only and exits.
   --require-target-create: with --check, fails unless Target.createTarget is enabled in popup settings; can be used without --tab-id for first-tab creation workflows.
-  --tab-id: binds this run to a specific Chrome tab id using a relay session lease.
+  --tab-id: binds this run to a specific tab id using a relay session lease.
+  --tab-ref: binds this run to a browser-scoped tab ref from relay status, formatted as browserId:tabId.
+  --browser-id: targets a specific connected browser/profile, mainly for Target.createTarget or disambiguation.
   --metadata: fetches active tab URL/title metadata without forcing DOM attach.
   --screenshot: capture a screenshot via CDP Page.captureScreenshot.
   --screenshot-path: when set, writes the image file and returns its absolute path in JSON.
@@ -2598,6 +2670,7 @@ Examples:
   node read-active-tab.js --preset whatsapp-messages --message-regex "invoice|payment" --selector "#main"
   node read-active-tab.js --preset chat-audit --text-regex "hello|hey" --sender-regex "Mathias"
   node read-active-tab.js --tab-id 123 --expression-file "./tmp/expression.js"
+  node read-active-tab.js --tab-ref chrome-profile:123 --expression-file "./tmp/expression.js"
   cat ./tmp/expression.js | node read-active-tab.js --tab-id 123 --expression-stdin
   node read-active-tab.js --link-text-regex "docs|help" --link-href-regex "grais"
   node read-active-tab.js --screenshot --screenshot-path "./tmp/page.png"

--- a/scripts/relay-manager.js
+++ b/scripts/relay-manager.js
@@ -296,20 +296,22 @@ function enrichPortLeaseSummary(entry) {
   const leasedAttachedTabs = attachedTabs
     .filter((tab) => typeof tab?.leasedSessionId === 'string' && tab.leasedSessionId.length > 0)
     .map((tab) => ({
+      tabRef: typeof tab.tabRef === 'string' ? tab.tabRef : null,
       tabId: tab.tabId,
+      browserId: typeof tab.browserId === 'string' ? tab.browserId : null,
       sessionId: tab.leasedSessionId,
       title: tab.title || null,
       url: tab.url || null,
     }))
   const availableAttachedTabIds = attachedTabs
     .filter((tab) => !tab?.leasedSessionId)
-    .map((tab) => tab.tabId)
-    .filter(Number.isInteger)
-    .sort((a, b) => a - b)
+    .map((tab) => (typeof tab.tabRef === 'string' ? tab.tabRef : tab.tabId))
+    .filter((value) => typeof value === 'string' || Number.isInteger(value))
+    .sort((a, b) => String(a).localeCompare(String(b)))
   const attachedTabIds = attachedTabs
-    .map((tab) => tab.tabId)
-    .filter(Number.isInteger)
-    .sort((a, b) => a - b)
+    .map((tab) => (typeof tab.tabRef === 'string' ? tab.tabRef : tab.tabId))
+    .filter((value) => typeof value === 'string' || Number.isInteger(value))
+    .sort((a, b) => String(a).localeCompare(String(b)))
   const staleTabLeases = Array.isArray(entry?.staleTabLeases) ? entry.staleTabLeases : []
 
   return {
@@ -348,6 +350,12 @@ async function runDoctor() {
 
   if (args.tabId !== undefined) {
     childArgs.push('--tab-id', String(parsePositiveInt(args.tabId, 1, '--tab-id')))
+  }
+  if (args.tabRef !== undefined) {
+    childArgs.push('--tab-ref', String(args.tabRef))
+  }
+  if (args.browserId !== undefined) {
+    childArgs.push('--browser-id', String(args.browserId))
   }
   if (args.requireTargetCreate === true) {
     childArgs.push('--require-target-create')
@@ -696,6 +704,8 @@ function parseArgs(argv) {
     else if (arg === '--port' && argv[i + 1]) out.port = argv[++i]
     else if (arg === '--ports' && argv[i + 1]) out.ports = argv[++i]
     else if (arg === '--tab-id' && argv[i + 1]) out.tabId = argv[++i]
+    else if (arg === '--tab-ref' && argv[i + 1]) out.tabRef = argv[++i]
+    else if (arg === '--browser-id' && argv[i + 1]) out.browserId = argv[++i]
     else if (arg === '--timeout' && argv[i + 1]) out.timeout = argv[++i]
     else if (arg === '--start-timeout-ms' && argv[i + 1]) out.startTimeoutMs = argv[++i]
     else if (arg === '--action' && argv[i + 1]) out.action = argv[++i]
@@ -717,7 +727,7 @@ function printUsage() {
   Override with --host / --port / --ports when needed.
   node scripts/relay-manager.js start [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--ports ${DEFAULT_PORT},18794] [--timeout 12000] [--status-timeout-ms 1200] [--start-timeout-ms 10000] [--auto-stop-ms 0]
   node scripts/relay-manager.js status [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--ports ${DEFAULT_PORT},18794] [--status-timeout-ms 1200] [--all]
-  node scripts/relay-manager.js doctor [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--tab-id 123] [--require-target-create] [--status-timeout-ms 1200] [--attach-timeout-ms 120000] [--json]
+  node scripts/relay-manager.js doctor [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--tab-id 123] [--tab-ref browserId:123] [--browser-id browserId] [--require-target-create] [--status-timeout-ms 1200] [--attach-timeout-ms 120000] [--json]
   node scripts/relay-manager.js ports [--host ${DEFAULT_HOST}] --action add|remove --ports ${DEFAULT_PORT},18794 [--status-timeout-ms 1200]
   node scripts/relay-manager.js stop [--host ${DEFAULT_HOST}] [--port ${DEFAULT_PORT}] [--status-timeout-ms 1200]
 `)

--- a/tests/multi-browser-relay.test.js
+++ b/tests/multi-browser-relay.test.js
@@ -1,0 +1,303 @@
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const http = require('node:http');
+const path = require('node:path');
+const test = require('node:test');
+const { WebSocket } = require('ws');
+
+const root = path.resolve(__dirname, '..');
+
+function getFreePort(host) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.once('error', reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      server.close(() => {
+        if (!address || typeof address === 'string') {
+          reject(new Error('Failed to allocate test port'));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+function waitForLine(child, pattern) {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const onData = (chunk) => {
+      buffer += String(chunk || '');
+      if (!pattern.test(buffer)) return;
+      cleanup();
+      resolve(buffer);
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(new Error(`Relay exited before readiness: code=${code} signal=${signal} output=${buffer}`));
+    };
+    const cleanup = () => {
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('exit', onExit);
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.once('exit', onExit);
+  });
+}
+
+function stopRelay(child) {
+  return new Promise((resolve) => {
+    if (!child || child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+
+    const killTimer = setTimeout(() => {
+      child.kill('SIGKILL');
+    }, 1000);
+    killTimer.unref?.();
+
+    child.once('exit', () => {
+      clearTimeout(killTimer);
+      resolve();
+    });
+    child.kill('SIGTERM');
+  });
+}
+
+function closeSocket(socket) {
+  return new Promise((resolve) => {
+    if (!socket || socket.readyState === WebSocket.CLOSED) {
+      resolve();
+      return;
+    }
+
+    const timer = setTimeout(resolve, 250);
+    timer.unref?.();
+    socket.once('close', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+
+    if (socket.readyState === WebSocket.CONNECTING) {
+      socket.terminate();
+      return;
+    }
+    socket.close();
+  });
+}
+
+function connectExtension(host, port, browser, attachedTabs) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://${host}:${port}/extension`);
+    socket.once('error', reject);
+    socket.once('open', () => {
+      socket.send(JSON.stringify({
+        method: 'Grais.extensionHeartbeat',
+        ts: Date.now(),
+        relayPort: port,
+        state: 'attached',
+        status: 'ON',
+        allowTargetCreate: false,
+        activeTab: attachedTabs[0] || null,
+        attachedTabs,
+        extensionVersion: '0.0.14',
+        extensionName: 'Agent Browser Relay',
+        browser,
+      }));
+      resolve(socket);
+    });
+  });
+}
+
+function connectController(host, port) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://${host}:${port}/extension`);
+    socket.once('error', reject);
+    socket.once('open', () => resolve(socket));
+  });
+}
+
+function waitForSocketJson(socket, predicate) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for socket message'));
+    }, 1200);
+    const onMessage = (raw) => {
+      let payload;
+      try {
+        payload = JSON.parse(String(raw || ''));
+      } catch {
+        return;
+      }
+      if (!predicate(payload)) return;
+      cleanup();
+      resolve(payload);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off('message', onMessage);
+    };
+    socket.on('message', onMessage);
+  });
+}
+
+function sendRequest(socket, id, method, params) {
+  socket.send(JSON.stringify({
+    id,
+    method,
+    ...(params !== undefined ? { params } : {}),
+  }));
+}
+
+function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout: 1200 }, (response) => {
+      let body = '';
+      response.on('data', (chunk) => {
+        body += String(chunk || '');
+      });
+      response.on('end', () => {
+        try {
+          resolve(JSON.parse(body || '{}'));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    req.on('timeout', () => req.destroy(new Error('HTTP timeout')));
+    req.on('error', reject);
+  });
+}
+
+test('one relay port keeps multiple browser extension clients connected', async (t) => {
+  const host = 'localhost';
+  const port = await getFreePort(host);
+  const relay = spawn(process.execPath, [
+    path.join(root, 'relay-server.js'),
+    '--host',
+    host,
+    '--port',
+    String(port),
+    '--timeout',
+    '1200',
+  ], {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  t.after(() => {
+    return stopRelay(relay);
+  });
+
+  await waitForLine(relay, /Agent Browser Relay listening/);
+
+  const chrome = await connectExtension(host, port, {
+    name: 'Chrome',
+    family: 'chromium',
+    version: '148.0.0.0',
+    profileId: 'chrome-profile',
+  }, [
+    { tabId: 101, title: 'Chrome tab', url: 'https://chrome.example/', windowId: 1, sessionId: 'chrome-session', targetId: 'chrome-target', state: 'connected' },
+  ]);
+  t.after(() => closeSocket(chrome));
+
+  const brave = await connectExtension(host, port, {
+    name: 'Brave',
+    family: 'chromium',
+    version: '148.0.0.0',
+    profileId: 'brave-profile',
+  }, [
+    { tabId: 101, title: 'Brave tab', url: 'https://brave.example/', windowId: 2, sessionId: 'brave-session', targetId: 'brave-target', state: 'connected' },
+  ]);
+  t.after(() => closeSocket(brave));
+
+  const status = await fetchJson(`http://${host}:${port}/status?all=true`);
+  const portStatus = status.ports.find((entry) => entry.port === port);
+
+  assert.equal(status.extensionConnected, true);
+  assert.equal(portStatus.extensionConnected, true);
+  assert.deepEqual(
+    portStatus.browsers.map((entry) => entry.browser.profileId).sort(),
+    ['brave-profile', 'chrome-profile'],
+  );
+  assert.deepEqual(
+    portStatus.attachedTabs.map((entry) => entry.tabRef).sort(),
+    ['brave-profile:101', 'chrome-profile:101'],
+  );
+});
+
+test('tabRef leases route duplicate tab ids to the owning browser', async (t) => {
+  const host = 'localhost';
+  const port = await getFreePort(host);
+  const relay = spawn(process.execPath, [
+    path.join(root, 'relay-server.js'),
+    '--host',
+    host,
+    '--port',
+    String(port),
+    '--timeout',
+    '1200',
+  ], {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  t.after(() => {
+    return stopRelay(relay);
+  });
+
+  await waitForLine(relay, /Agent Browser Relay listening/);
+
+  const chrome = await connectExtension(host, port, {
+    name: 'Chrome',
+    family: 'chromium',
+    version: '148.0.0.0',
+    profileId: 'chrome-profile',
+  }, [
+    { tabId: 101, title: 'Chrome tab', url: 'https://chrome.example/', windowId: 1, sessionId: 'chrome-session', targetId: 'chrome-target', state: 'connected' },
+  ]);
+  t.after(() => closeSocket(chrome));
+
+  const brave = await connectExtension(host, port, {
+    name: 'Brave',
+    family: 'chromium',
+    version: '148.0.0.0',
+    profileId: 'brave-profile',
+  }, [
+    { tabId: 101, title: 'Brave tab', url: 'https://brave.example/', windowId: 2, sessionId: 'brave-session', targetId: 'brave-target', state: 'connected' },
+  ]);
+  t.after(() => closeSocket(brave));
+
+  const controller = await connectController(host, port);
+  t.after(() => closeSocket(controller));
+
+  sendRequest(controller, 1, 'Grais.relay.openSession', {
+    client: 'test',
+    tabRef: 'brave-profile:101',
+  });
+  const session = await waitForSocketJson(controller, (payload) => payload.id === 1);
+  assert.equal(session.result.tabRef, 'brave-profile:101');
+
+  sendRequest(controller, 2, 'forwardCDPCommand', {
+    relaySessionId: session.result.sessionId,
+    method: 'Runtime.evaluate',
+    params: { expression: 'document.title' },
+  });
+
+  const braveCommand = await waitForSocketJson(brave, (payload) => payload.method === 'forwardCDPCommand');
+  assert.equal(braveCommand.params.browserId, 'brave-profile');
+  assert.equal(braveCommand.params.tabId, 101);
+  assert.equal(braveCommand.params.tabRef, 'brave-profile:101');
+
+  let chromeReceived = false;
+  chrome.once('message', () => {
+    chromeReceived = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  assert.equal(chromeReceived, false);
+});


### PR DESCRIPTION
Summary
- Adds one relay hub that keeps multiple browser/profile extension clients connected on the same port.
- Introduces browser-scoped `tabRef` routing so duplicate numeric tab ids are handled deterministically.
- Updates doctor/read CLIs, popup version display, docs, and release metadata.

Why
- Running the extension in 1-3 browsers should not make the relay badge flap between connected and disconnected states. The old relay treated the latest extension socket as the only extension and displaced the previous browser.

What changed
- Relay state now tracks extension clients by `browserId` and aggregates health/status across them.
- Tab leases and CDP forwarding route by `tabRef` / `browserId` while retaining legacy single-browser `--tab-id` behavior when unambiguous.
- `read-active-tab`, `relay-manager doctor`, and `extension-status` expose the new routing fields.
- The popup version now renders from the manifest instead of a hard-coded string.
- Version bumped forward to `0.0.14` because `main` was already at `0.0.13`.

Files changed
- `relay-server.js`
- `scripts/read-active-tab.js`
- `scripts/relay-manager.js`
- `scripts/extension-status.js`
- `extension/popup.html`, `extension/popup.js`, `extension/manifest.json`
- `README.md`, `SKILL.md`, `AGENTS.md`, `CHANGELOG.md`, `package.json`
- `tests/multi-browser-relay.test.js`

Validation
- `pnpm build`
- `pnpm test`
- `node --check tests/multi-browser-relay.test.js`
- `git diff --check`

Risks and impacts
- The main compatibility risk is status/lease consumers that assumed raw numeric tab ids were globally unique. Legacy single-browser `--tab-id` behavior still works when the tab id is unambiguous; duplicate ids now require `tabRef` or `browserId`.

Rollback plan
- Revert this commit and reinstall/reload the previous extension bundle.

Related issues
- None.

Checklist
- [x] Implementation complete
- [x] Version bumped
- [x] Tests pass
- [x] Docs updated